### PR TITLE
feat!: Scoped References

### DIFF
--- a/src/bluefish.tsx
+++ b/src/bluefish.tsx
@@ -11,6 +11,8 @@ import {
   ChildNode,
 } from "./scenegraph";
 import { JSX, ParentProps, Show, createUniqueId, mergeProps } from "solid-js";
+import { ParentScopeIdContext, Scope, ScopeContext } from "./createName";
+import { createStore } from "solid-js/store";
 
 export type BluefishProps = ParentProps<{
   width?: number;
@@ -41,10 +43,14 @@ export function Bluefish(props: BluefishProps) {
   // const bboxStore = createScenegraph();
   const scenegraphContext = createScenegraph();
   const { scenegraph, createNode } = scenegraphContext;
+  const [scope, setScope] = createStore<Scope>({});
 
   // const autoGenId = useId();
   const autoGenId = createUniqueId();
-  const id = props.id ?? autoGenId;
+  const autoGenScopeId = createUniqueId();
+  // const id = props.id ?? autoGenId;
+  const id = autoGenId;
+  const scopeId = props.id ?? autoGenScopeId;
   // const wroteToWindow = useRef(false);
 
   // useEffect(() => {
@@ -148,11 +154,15 @@ export function Bluefish(props: BluefishProps) {
   return (
     <>
       <ScenegraphContext.Provider value={scenegraphContext}>
-        <Layout name={id} layout={layout} paint={paint}>
-          <ParentIDContext.Provider value={id}>
-            {props.children}
-          </ParentIDContext.Provider>
-        </Layout>
+        <ScopeContext.Provider value={[scope, setScope]}>
+          <Layout name={id} layout={layout} paint={paint}>
+            <ParentScopeIdContext.Provider value={() => scopeId}>
+              <ParentIDContext.Provider value={id}>
+                {props.children}
+              </ParentIDContext.Provider>
+            </ParentScopeIdContext.Provider>
+          </Layout>
+        </ScopeContext.Provider>
       </ScenegraphContext.Provider>
       <Show when={props.debug === true}>
         <pre>{JSON.stringify(scenegraph, null, 2)}</pre>

--- a/src/bluefish.tsx
+++ b/src/bluefish.tsx
@@ -48,7 +48,6 @@ export function Bluefish(props: BluefishProps) {
   // const autoGenId = useId();
   const autoGenId = createUniqueId();
   const autoGenScopeId = createUniqueId();
-  // const id = props.id ?? autoGenId;
   const id = autoGenId;
   const scopeId = props.id ?? autoGenScopeId;
   // const wroteToWindow = useRef(false);

--- a/src/createName.tsx
+++ b/src/createName.tsx
@@ -40,6 +40,8 @@ export const createName = (name: string) => {
     children: {},
   }); // inside withBluefish, we first check if we have a props.name as input, which will then become the parent context. otherwise we'll generate a new id for the parent context
   setScope(parentId(), "children", name, genId);
+  console.log(`added ${name} to scope ${parentId()}`);
+  console.log(`${name} refers to scope ${genId}`);
 
   return genId;
 };

--- a/src/createName.tsx
+++ b/src/createName.tsx
@@ -14,6 +14,7 @@ draw this out. it's too hard to see
 export type Scope = {
   [key: Id]: {
     layoutNode: Id | undefined;
+    parent: Id; // TODO: not sure if this is used. might be useful for debugging/error reporting, though
     children: { [key: Name]: Id };
   };
 };
@@ -34,17 +35,15 @@ export const createName = (name: string) => {
 
   // setScope(name, genId);
   setScope(genId, {
+    parent: parentId(),
     layoutNode: undefined,
     children: {},
   }); // inside withBluefish, we first check if we have a props.name as input, which will then become the parent context. otherwise we'll generate a new id for the parent context
   setScope(parentId(), "children", name, genId);
 
-  return { scopedName: genId };
+  return genId;
 };
 
 /* 
-TODO:
-- in layout: associate this id with a layout node id
-- in ref: lookup the id to get the layout node id
-- in withBluefish: need to ensure that props.name is always an id
+TODO: initialize
 */

--- a/src/createName.tsx
+++ b/src/createName.tsx
@@ -26,7 +26,7 @@ export const ScopeContext = createContext<
 export const ParentScopeIdContext = createContext<Accessor<Name>>(() => "");
 
 export const createName = (name: string) => {
-  const genId = createUniqueId();
+  const genId = `${name}-${createUniqueId()}`;
 
   const [scope, setScope] = useContext(ScopeContext);
   const parentId = useContext(ParentScopeIdContext);
@@ -40,8 +40,6 @@ export const createName = (name: string) => {
     children: {},
   }); // inside withBluefish, we first check if we have a props.name as input, which will then become the parent context. otherwise we'll generate a new id for the parent context
   setScope(parentId(), "children", name, genId);
-  console.log(`added ${name} to scope ${parentId()}`);
-  console.log(`${name} refers to scope ${genId}`);
 
   return genId;
 };

--- a/src/createName.tsx
+++ b/src/createName.tsx
@@ -43,7 +43,3 @@ export const createName = (name: string) => {
 
   return genId;
 };
-
-/* 
-TODO: initialize
-*/

--- a/src/createName.tsx
+++ b/src/createName.tsx
@@ -1,0 +1,50 @@
+import { Accessor, createContext, createUniqueId, useContext } from "solid-js";
+import { SetStoreFunction, Store } from "solid-js/store";
+import { Id } from "./scenegraph";
+
+export type Name = string;
+
+/* 
+TODO: This is wrong!!!
+A name should either point to an id of another name or else point to an id of a layout node.
+
+draw this out. it's too hard to see
+*/
+
+export type Scope = {
+  [key: Id]: {
+    layoutNode: Id | undefined;
+    children: { [key: Name]: Id };
+  };
+};
+
+// the scope context is a map from uid to a set of names that map to other uids
+export const ScopeContext = createContext<
+  [get: Store<Scope>, set: SetStoreFunction<Scope>]
+>([{}, () => {}]);
+export const ParentScopeIdContext = createContext<Accessor<Name>>(() => "");
+
+export const createName = (name: string) => {
+  const genId = createUniqueId();
+
+  const [scope, setScope] = useContext(ScopeContext);
+  const parentId = useContext(ParentScopeIdContext);
+
+  // TODO: check if it exists before adding
+
+  // setScope(name, genId);
+  setScope(genId, {
+    layoutNode: undefined,
+    children: {},
+  }); // inside withBluefish, we first check if we have a props.name as input, which will then become the parent context. otherwise we'll generate a new id for the parent context
+  setScope(parentId(), "children", name, genId);
+
+  return { scopedName: genId };
+};
+
+/* 
+TODO:
+- in layout: associate this id with a layout node id
+- in ref: lookup the id to get the layout node id
+- in withBluefish: need to ensure that props.name is always an id
+*/

--- a/src/gradient.tsx
+++ b/src/gradient.tsx
@@ -1,9 +1,10 @@
+import { For } from "solid-js";
 import withBluefish from "./withBluefish";
 
 type ColorOffset = { offset: number; color: string };
 
 type GradientProps = {
-  name: string;
+  id: string;
   colorOffsets: ColorOffset[];
   x1?: number;
   x2?: number;
@@ -11,25 +12,27 @@ type GradientProps = {
   y2?: number;
 };
 
-export const Gradient = withBluefish((props: GradientProps) => {
+export const Gradient = (props: GradientProps) => {
   return (
     <g>
       <linearGradient
-        id={props.name}
+        id={props.id}
         x1={props.x1}
         x2={props.x2}
         y1={props.y1}
         y2={props.y2}
       >
-        {props.colorOffsets.map((colorOffset) => (
-          <stop
-            offset={`${colorOffset.offset}%`}
-            stop-color={colorOffset.color}
-          />
-        ))}
+        <For each={props.colorOffsets}>
+          {(colorOffset) => (
+            <stop
+              offset={`${colorOffset.offset}%`}
+              stop-color={colorOffset.color}
+            />
+          )}
+        </For>
       </linearGradient>
     </g>
   );
-});
+};
 
 export default Gradient;

--- a/src/python-tutor/elm-tuple.tsx
+++ b/src/python-tutor/elm-tuple.tsx
@@ -7,6 +7,7 @@ import { Id } from "../../src/scenegraph";
 import { Text } from "../../src/text";
 import { Value } from "./types";
 import { createName } from "../createName";
+import withBluefish from "../withBluefish";
 
 export type ElmTupleProps = {
   name?: Id;
@@ -14,7 +15,7 @@ export type ElmTupleProps = {
   tupleData: { type: string; value: Value };
 };
 
-export function ElmTuple(props: ElmTupleProps) {
+export const ElmTuple = withBluefish((props: ElmTupleProps) => {
   const fontFamily = "verdana, arial, helvetica, sans-serif";
 
   const boxName = createName("box");
@@ -62,6 +63,6 @@ export function ElmTuple(props: ElmTupleProps) {
       </Align>
     </Group>
   );
-}
+});
 
 export default ElmTuple;

--- a/src/python-tutor/elm-tuple.tsx
+++ b/src/python-tutor/elm-tuple.tsx
@@ -6,45 +6,41 @@ import { Ref } from "../../src/ref";
 import { Id } from "../../src/scenegraph";
 import { Text } from "../../src/text";
 import { Value } from "./types";
+import { createName } from "../createName";
 
 export type ElmTupleProps = {
-  x?: number;
-  y?: number;
   name?: Id;
   tupleIndex: string;
   tupleData: { type: string; value: Value };
-  objectId: string;
 };
 
 export function ElmTuple(props: ElmTupleProps) {
-  const id = createUniqueId();
   const fontFamily = "verdana, arial, helvetica, sans-serif";
 
+  const boxName = createName("box");
+  const labelName = createName("label");
+  const valName = createName("val");
+
   return (
-    <Group
-      name={props.name ?? `elm_${props.tupleIndex}_${props.objectId}`}
-      x={props.x}
-      y={props.y}
-    >
+    <Group>
       <Rect
-        name={`elmBox_${props.tupleIndex}_${props.objectId}`}
+        name={boxName}
         height={60}
         width={70}
         fill={"#ffffc6"}
         stroke={"grey"}
       />
       <Text
-        name={`elmLabel_${props.tupleIndex}_${props.objectId}`}
+        name={labelName}
         font-family={fontFamily}
         font-size={"16px"}
         fill={"gray"}
       >
         {props.tupleIndex}
       </Text>
-
       {props.tupleData.type === "string" ? (
         <Text
-          name={`elmVal_${props.tupleIndex}_${props.objectId}`}
+          name={valName}
           font-size={"24px"}
           font-family={fontFamily}
           fill={"black"}
@@ -52,20 +48,17 @@ export function ElmTuple(props: ElmTupleProps) {
           {props.tupleData.value as string}
         </Text>
       ) : (
-        <Text
-          name={`elmVal_${props.tupleIndex}_${props.objectId}`}
-          fill={"none"}
-        >
+        <Text name={valName} fill={"none"}>
           {""}
         </Text>
       )}
       <Align alignment="center">
-        <Ref select={`elmVal_${props.tupleIndex}_${props.objectId}`} />
-        <Ref select={`elmBox_${props.tupleIndex}_${props.objectId}`} />
+        <Ref select={valName} />
+        <Ref select={boxName} />
       </Align>
       <Align alignment="topLeft">
-        <Ref select={`elmLabel_${props.tupleIndex}_${props.objectId}`} />
-        <Ref select={`elmBox_${props.tupleIndex}_${props.objectId}`} />
+        <Ref select={labelName} />
+        <Ref select={boxName} />
       </Align>
     </Group>
   );

--- a/src/python-tutor/global-frame.tsx
+++ b/src/python-tutor/global-frame.tsx
@@ -10,13 +10,14 @@ import Text from "../../src/text";
 import { Value } from "./types";
 import { createName } from "../createName";
 import { StackV } from "../stackv";
+import withBluefish from "../withBluefish";
 
 export type GlobalFrameProps = {
   name?: Id;
   variables: { variable: string; value: Value }[];
 };
 
-export function GlobalFrame(props: GlobalFrameProps) {
+export const GlobalFrame = withBluefish((props: GlobalFrameProps) => {
   const frameName = createName("frame");
   const frameBorderName = createName("frameBorder");
   const labelName = createName("label");
@@ -67,6 +68,6 @@ export function GlobalFrame(props: GlobalFrameProps) {
       </StackV>
     </Group>
   );
-}
+});
 
 export default GlobalFrame;

--- a/src/python-tutor/global-frame.tsx
+++ b/src/python-tutor/global-frame.tsx
@@ -8,6 +8,8 @@ import { StackSlot } from "./stack-slot";
 import Distribute from "../../src/distribute";
 import Text from "../../src/text";
 import { Value } from "./types";
+import { createName } from "../createName";
+import { StackV } from "../stackv";
 
 export type GlobalFrameProps = {
   name?: Id;
@@ -15,19 +17,25 @@ export type GlobalFrameProps = {
 };
 
 export function GlobalFrame(props: GlobalFrameProps) {
-  const id = props.name ?? createUniqueId();
+  const frameName = createName("frame");
+  const frameBorderName = createName("frameBorder");
+  const labelName = createName("label");
+  const frameVariablesName = createName("frameVariables");
+  const stackSlotNames = props.variables.map((_, i) =>
+    createName(`stackSlot-${i}`)
+  );
 
   // Font declaration
   const fontFamily = "Andale mono, monospace";
 
   return (
-    <Group x={0} y={0} name={props.name ?? `group_${id}`}>
+    <Group>
       {/* Global Frame and relevant text */}
-      <Rect name={`frame${id}`} height={300} width={200} fill={"#e2ebf6"} />
-      <Rect name={`frameBorder${id}`} height={300} width={5} fill={"#a6b3b6"} />
+      <Rect name={frameName} height={300} width={200} fill={"#e2ebf6"} />
+      <Rect name={frameBorderName} height={300} width={5} fill={"#a6b3b6"} />
       {/* TODO: there is a bug where the text is showing up lower than I expect it to... */}
       <Text
-        name={`label${id}`}
+        name={labelName}
         font-size={"24px"}
         font-family={fontFamily}
         fill={"black"}
@@ -35,42 +43,28 @@ export function GlobalFrame(props: GlobalFrameProps) {
         Global Frame
       </Text>
       <Align alignment="topCenter">
-        <Ref select={`label${id}`} />
-        <Ref select={`frame${id}`} />
+        <Ref select={labelName} />
+        <Ref select={frameName} />
       </Align>
       <Align alignment="centerLeft">
-        <Ref select={`frameBorder${id}`} />
-        <Ref select={`frame${id}`} />
+        <Ref select={frameBorderName} />
+        <Ref select={frameName} />
       </Align>
-      <Group name={`frameVariables${id}`}>
+      <StackV name={frameVariablesName} alignment="right" spacing={10}>
         <For each={props.variables}>
-          {(variable: any, i) => (
+          {(variable, i) => (
             <StackSlot
-              name={`stackSlot${i()}_${id}`}
+              name={stackSlotNames[i()]}
               variable={variable.variable}
-              value={variable.value}
+              value={variable.value as any}
             />
           )}
         </For>
-        <Align alignment="right">
-          <For each={props.variables}>
-            {(variable: any, i) => <Ref select={`stackSlot${i()}_${id}`} />}
-          </For>
-        </Align>
-        <Distribute direction="vertical" spacing={10}>
-          <For each={props.variables}>
-            {(variable: any, i) => <Ref select={`stackSlot${i()}_${id}`} />}
-          </For>
-        </Distribute>
-      </Group>
-      <Distribute direction="vertical" spacing={10}>
-        <Ref select={`label${id}`} />
-        <Ref select={`frameVariables${id}`} />
-      </Distribute>
-      <Align alignment="right">
-        <Ref select={`frameVariables${id}`} />
-        <Ref select={`label${id}`} />
-      </Align>
+      </StackV>
+      <StackV alignment="right" spacing={10}>
+        <Ref select={labelName} />
+        <Ref select={frameVariablesName} />
+      </StackV>
     </Group>
   );
 }

--- a/src/python-tutor/heap-object.tsx
+++ b/src/python-tutor/heap-object.tsx
@@ -8,6 +8,9 @@ import { For, createUniqueId } from "solid-js";
 import ElmTuple from "./elm-tuple";
 import withBluefish from "../../src/withBluefish";
 import { Value } from "./types";
+import { createName } from "../createName";
+import { StackH } from "../stackh";
+import { StackV } from "../stackv";
 
 export type ObjectProps = {
   name: Id;
@@ -19,53 +22,35 @@ export type ObjectProps = {
 };
 
 export const HeapObject = withBluefish((props: ObjectProps) => {
-  const id = () => props.name;
-
   const fontFamily = "verdana, arial, helvetica, sans-serif";
 
-  const objectRef = `objectRef${id()}`;
+  const objectTypeName = createName("objectType");
+  const objectRefName = createName("objectRef");
+
+  const elmNames = props.objectValues.map((_, i) => createName(`elm-${i}`));
 
   return (
-    <Group name={id()}>
+    <StackV alignment="left" spacing={10}>
       <Text
-        name={`objectTypeRef${id()}`}
+        name={objectTypeName}
         font-family={fontFamily}
         font-size={"16px"}
         fill={"grey"}
       >
         {props.objectType}
       </Text>
-      <Group name={objectRef}>
+      <StackH name={objectRefName} spacing={0}>
         <For each={props.objectValues}>
           {(elementData, index) => (
             <ElmTuple
-              name={`elm_${index()}_${id()}`}
+              name={elmNames[index()]}
               tupleIndex={`${index()}`}
               tupleData={elementData}
-              objectId={id()}
             />
           )}
         </For>
-        <Align alignment="centerY">
-          <For each={props.objectValues}>
-            {(elementData, index) => <Ref select={`elm_${index()}_${id()}`} />}
-          </For>
-        </Align>
-        <Distribute direction="horizontal" spacing={0}>
-          <For each={props.objectValues}>
-            {(elementData, index) => <Ref select={`elm_${index()}_${id()}`} />}
-          </For>
-        </Distribute>
-      </Group>
-      <Distribute direction={"vertical"} spacing={10}>
-        <Ref select={`objectTypeRef${id()}`} />
-        <Ref select={objectRef} />
-      </Distribute>
-      <Align alignment={"left"}>
-        <Ref select={`objectTypeRef${id()}`} />
-        <Ref select={objectRef} />
-      </Align>
-    </Group>
+      </StackH>
+    </StackV>
   );
 });
 

--- a/src/python-tutor/heap.tsx
+++ b/src/python-tutor/heap.tsx
@@ -65,10 +65,6 @@ export const Heap = withBluefish((props: HeapProps) => {
                 "type" in elmTupleValue &&
                 elmTupleValue.type === "pointer"
               ) {
-                // TODO: come back to this to get more precise starting point
-                // const fromId = `elmVal_${elmTupleIndex()}_${objectIdToComponentId.get(
-                //   address()
-                // )}`;
                 return (
                   <Arrow
                     bow={0}

--- a/src/python-tutor/heap.tsx
+++ b/src/python-tutor/heap.tsx
@@ -80,10 +80,13 @@ export const Heap = withBluefish((props: HeapProps) => {
                     <Ref
                       select={[
                         addressNames[address()],
-                        // `elm-${elmTupleIndex()}`,
+                        `elm-${elmTupleIndex()}`,
+                        "val",
                       ]}
                     />
-                    <Ref select={addressNames[elmTupleValue.value]} />
+                    <Ref
+                      select={[addressNames[elmTupleValue.value], "elm-0"]}
+                    />
                   </Arrow>
                 );
               }

--- a/src/python-tutor/heap.tsx
+++ b/src/python-tutor/heap.tsx
@@ -20,25 +20,6 @@ export type HeapProps = {
 };
 
 export const Heap = withBluefish((props: HeapProps) => {
-  // Maps object number to the ID of the corresponding heap object
-  // This will help generate Arrows between objects
-  const objectIdToComponentId = new Map<number, string>();
-  props.heapArrangement.forEach((row, rowIndex) => {
-    row.forEach((obj, colIndex) => {
-      if (obj !== null) {
-        objectIdToComponentId.set(obj, `row${rowIndex}_col${colIndex}`);
-      }
-    });
-  });
-
-  // const addressNames = new Map<Address, Id>();
-  // for (const row of props.heapArrangement) {
-  //   for (const address of row) {
-  //     if (address !== null) {
-  //       addressNames.set(address, createName(`address-${address}`));
-  //     }
-  //   }
-  // }
   const addressNames = props.heap.map((_, i) => createName(`address-${i}`));
 
   return (

--- a/src/python-tutor/stack-slot.tsx
+++ b/src/python-tutor/stack-slot.tsx
@@ -8,6 +8,7 @@ import { createUniqueId } from "solid-js";
 import { Id } from "../../src/scenegraph";
 import { Pointer } from "./types";
 import withBluefish from "../withBluefish";
+import { createName } from "../createName";
 
 export type StackSlotProps = {
   name?: Id;
@@ -16,64 +17,49 @@ export type StackSlotProps = {
 };
 
 export const StackSlot = withBluefish((props: StackSlotProps) => {
-  const id = props.name;
   const fontFamily = "verdana, arial, helvetica, sans-serif";
+
+  const boxName = createName("box");
+  const nameName = createName("name");
+  const valueName = createName("value");
 
   return (
     <Group>
-      <Rect name={`box_${id}`} y={0} height={40} width={40} fill={"#e2ebf6"} />
-      <Text name={`name_${id}`} font-size={"24px"} font-family={fontFamily}>
+      <Rect name={boxName} y={0} height={40} width={40} fill={"#e2ebf6"} />
+      <Text name={nameName} font-size={"24px"} font-family={fontFamily}>
         {props.variable}
       </Text>
       {/* TODO: if we only align or distribute on a single dimension, then their bounding boxes should be null or something along the unconstrained dimension... */}
       <Align alignment="centerY">
-        <Ref select={`name_${id}`} />
-        <Ref select={`box_${id}`} />
+        <Ref select={nameName} />
+        <Ref select={boxName} />
       </Align>
       <Distribute direction="horizontal" spacing={5}>
-        <Ref select={`name_${id}`} />
-        <Ref select={`box_${id}`} />
+        <Ref select={nameName} />
+        <Ref select={boxName} />
       </Distribute>
       <Align alignment="bottomCenter">
-        <Rect
-          name={`boxBorderBottom${id}`}
-          height={2}
-          width={40}
-          fill={"#a6b3b6"}
-        />
-        <Ref select={`box_${id}`} />
+        <Rect height={2} width={40} fill={"#a6b3b6"} />
+        <Ref select={boxName} />
       </Align>
       <Align alignment="centerLeft">
-        <Rect
-          name={`boxBorderLeft${id}`}
-          height={40}
-          width={2}
-          fill={"#a6b3b6"}
-        />
-        <Ref select={`box_${id}`} />
+        <Rect height={40} width={2} fill={"#a6b3b6"} />
+        <Ref select={boxName} />
       </Align>
 
       {typeof props.value === "string" ? (
         <Align alignment="center">
-          <Text
-            name={`valueName_${id}`}
-            font-size="24px"
-            font-family={fontFamily}
-          >
+          <Text name={valueName} font-size="24px" font-family={fontFamily}>
             {props.value}
           </Text>
-          <Ref select={`box_${id}`} />
+          <Ref select={boxName} />
         </Align>
       ) : (
         <Align alignment="center">
-          <Text
-            name={`valueName_${id}`}
-            font-size="24px"
-            font-family={fontFamily}
-          >
+          <Text name={valueName} font-size="24px" font-family={fontFamily}>
             {""}
           </Text>
-          <Ref select={`box_${id}`} />
+          <Ref select={boxName} />
         </Align>
       )}
     </Group>

--- a/src/ref.tsx
+++ b/src/ref.tsx
@@ -1,6 +1,7 @@
 import { Component, createEffect, useContext } from "solid-js";
 import { Id, UNSAFE_useScenegraph, ParentIDContext } from "./scenegraph";
 import withBluefish from "./withBluefish";
+import { ScopeContext } from "./createName";
 
 // The properties we want:
 // every time the refId's bbox is updated, it should be propagated to the id
@@ -22,12 +23,15 @@ export const Ref = withBluefish((props: RefProps) => {
   const { name, select } = props;
 
   const parentId = useContext(ParentIDContext);
+  const [scope] = useContext(ScopeContext);
   const { createRef, getBBox } = UNSAFE_useScenegraph();
 
   if (parentId === null) {
     throw new Error("Ref must be a child of a Layout");
   }
-  createRef(name, select, parentId);
+
+  // TODO: what do we do if the layout node isn't defined?
+  createRef(name, scope[select].layoutNode!, parentId);
 
   // touch the refId's bbox to ensure ref is resolved immediately
   // createEffect(() => {

--- a/src/ref.tsx
+++ b/src/ref.tsx
@@ -48,6 +48,7 @@ export const resolveSelection = (
   for (const name of names) {
     const child = scope[currId].children[name];
     if (child === undefined) {
+      console.log(JSON.parse(JSON.stringify(scope)));
       throw new Error(
         `Could not find ${name} in ${currId}. Available names: ${Object.keys(
           scope[currId].children

--- a/src/ref.tsx
+++ b/src/ref.tsx
@@ -58,7 +58,18 @@ export const resolveSelection = (
     currId = child;
   }
 
-  return scope[currId].layoutNode!;
+  const layoutId = scope[currId].layoutNode;
+
+  if (layoutId === undefined) {
+    console.log(JSON.parse(JSON.stringify(scope)));
+    throw new Error(
+      `Could not find layout node for ${currId}. Available names: ${Object.keys(
+        scope[currId].children
+      ).join(", ")}`
+    );
+  }
+
+  return layoutId;
 };
 
 export const Ref = withBluefish((props: RefProps) => {

--- a/src/stories/JetpackCompose.stories.tsx
+++ b/src/stories/JetpackCompose.stories.tsx
@@ -112,7 +112,7 @@ export const JetpackCompose: Story = {
           </StackH>
           <Group x={0} name="main-content">
             <Gradient
-              name="sleepBarGradient"
+              id="sleepBarGradient"
               colorOffsets={[
                 { offset: 0, color: "#F1E9BC" },
                 { offset: 100, color: "#f7d590" },
@@ -123,7 +123,7 @@ export const JetpackCompose: Story = {
               y2={1}
             />
             <Gradient
-              name="hoursBarGradient"
+              id="hoursBarGradient"
               colorOffsets={[
                 { offset: 0, color: "#f8e7a0" },
                 { offset: 100, color: "#f8d183" },

--- a/src/stories/PythonTutor.stories.tsx
+++ b/src/stories/PythonTutor.stories.tsx
@@ -55,26 +55,30 @@ const PythonTutor = withBluefish((props: PythonTutorProps) => {
       </StackH>
 
       {/* Make arrows from stack slots to heap objects */}
-      {/* <For each={props.stack}>
-        {(stackSlot, slackSlotIndex) =>
+      <For each={props.stack}>
+        {(stackSlot, stackSlotIndex) =>
           typeof stackSlot.value === "object" &&
           "type" in stackSlot.value &&
           stackSlot.value.type === "pointer" ? (
             <Arrow bow={0} stretch={0} flip stroke="#1A5683" padStart={0} start>
-              <Ref
+              {/* <Ref
                 select={`valueName_stackSlot${slackSlotIndex()}_globalFrame-${
                   props.name
                 }`}
-              />
+              /> */}
               <Ref
+                select={[globalFrameName, `stackSlot-${stackSlotIndex()}`]}
+              />
+              {/* <Ref
                 select={`elm_0_${objectIdToComponentId.get(
                   stackSlot.value.value
                 )}`}
-              />
+              /> */}
+              <Ref select={[heapName, `address-${stackSlot.value.value}`]} />
             </Arrow>
           ) : null
         }
-      </For> */}
+      </For>
     </Group>
   );
 });

--- a/src/stories/PythonTutor.stories.tsx
+++ b/src/stories/PythonTutor.stories.tsx
@@ -10,8 +10,10 @@ import { Ref } from "../ref";
 import { withBluefish, WithBluefishProps } from "../withBluefish";
 import { GlobalFrame } from "../python-tutor/global-frame";
 import { Heap } from "../python-tutor/heap";
-import { Address, HeapObject, StackSlot } from "../python-tutor/types";
+import { Address, HeapObject, StackSlot, pointer } from "../python-tutor/types";
 import { For } from "solid-js";
+import { createName } from "../createName";
+import { StackH } from "../stackh";
 
 const meta: Meta = {
   title: "Example/PythonTutor",
@@ -27,6 +29,9 @@ type PythonTutorProps = WithBluefishProps<{
 }>;
 
 const PythonTutor = withBluefish((props: PythonTutorProps) => {
+  const globalFrameName = createName("globalFrame");
+  const heapName = createName("heap");
+
   // Maps object number to the ID of the corresponding heap object
   // This will help generate Arrows between objects
   const objectIdToComponentId = new Map<number, string>();
@@ -39,27 +44,22 @@ const PythonTutor = withBluefish((props: PythonTutorProps) => {
   });
 
   return (
-    <Group name={props.name}>
-      <GlobalFrame name={`globalFrame-${props.name}`} variables={props.stack} />
-      <Heap
-        name={`heap-${props.name}`}
-        heap={props.heap}
-        heapArrangement={props.heapArrangement}
-      />
-      <Distribute direction="horizontal" spacing={60}>
-        <Ref select={`globalFrame-${props.name}`} />
-        <Ref select={`heap-${props.name}`} />
-      </Distribute>
-      <Align alignment="top">
-        <Ref select={`globalFrame-${props.name}`} />
-        <Ref select={`heap-${props.name}`} />
-      </Align>
+    <Group>
+      <StackH alignment="top" spacing={60}>
+        <GlobalFrame name={globalFrameName} variables={props.stack} />
+        <Heap
+          name={heapName}
+          heap={props.heap}
+          heapArrangement={props.heapArrangement}
+        />
+      </StackH>
 
       {/* Make arrows from stack slots to heap objects */}
-      <For each={props.stack}>
+      {/* <For each={props.stack}>
         {(stackSlot, slackSlotIndex) =>
-          typeof stackSlot.value !== "string" &&
-          typeof stackSlot.value !== "number" ? (
+          typeof stackSlot.value === "object" &&
+          "type" in stackSlot.value &&
+          stackSlot.value.type === "pointer" ? (
             <Arrow bow={0} stretch={0} flip stroke="#1A5683" padStart={0} start>
               <Ref
                 select={`valueName_stackSlot${slackSlotIndex()}_globalFrame-${
@@ -74,27 +74,22 @@ const PythonTutor = withBluefish((props: PythonTutorProps) => {
             </Arrow>
           ) : null
         }
-      </For>
+      </For> */}
     </Group>
   );
 });
 
 export const PythonTutorExample: Story = {
   args: {
-    id: "pt0",
     stack: [
-      { variable: "c", value: { type: "pointer", value: 0 } },
-      { variable: "d", value: { type: "pointer", value: 1 } },
+      { variable: "c", value: pointer(0) },
+      { variable: "d", value: pointer(1) },
       { variable: "x", value: "5" },
     ],
     heap: [
       {
         type: "tuple",
-        values: [
-          "1",
-          { type: "pointer", value: 1 },
-          { type: "pointer", value: 2 },
-        ],
+        values: ["1", pointer(1), pointer(2)],
       },
       { type: "tuple", values: ["1", "4"] },
       { type: "tuple", values: ["3", "10"] },

--- a/src/stories/PythonTutor.stories.tsx
+++ b/src/stories/PythonTutor.stories.tsx
@@ -61,20 +61,20 @@ const PythonTutor = withBluefish((props: PythonTutorProps) => {
           "type" in stackSlot.value &&
           stackSlot.value.type === "pointer" ? (
             <Arrow bow={0} stretch={0} flip stroke="#1A5683" padStart={0} start>
-              {/* <Ref
-                select={`valueName_stackSlot${slackSlotIndex()}_globalFrame-${
-                  props.name
-                }`}
-              /> */}
               <Ref
-                select={[globalFrameName, `stackSlot-${stackSlotIndex()}`]}
+                select={[
+                  globalFrameName,
+                  `stackSlot-${stackSlotIndex()}`,
+                  "value",
+                ]}
               />
-              {/* <Ref
-                select={`elm_0_${objectIdToComponentId.get(
-                  stackSlot.value.value
-                )}`}
-              /> */}
-              <Ref select={[heapName, `address-${stackSlot.value.value}`]} />
+              <Ref
+                select={[
+                  heapName,
+                  `address-${stackSlot.value.value}`,
+                  "objectRef",
+                ]}
+              />
             </Arrow>
           ) : null
         }
@@ -106,6 +106,7 @@ export const PythonTutorExample: Story = {
   render: (props) => (
     <Bluefish>
       <PythonTutor
+        name="python-tutor"
         {...props}
         heap={props.heap}
         heapArrangement={props.heapArrangement}

--- a/src/stories/PythonTutor.stories.tsx
+++ b/src/stories/PythonTutor.stories.tsx
@@ -69,11 +69,7 @@ const PythonTutor = withBluefish((props: PythonTutorProps) => {
                 ]}
               />
               <Ref
-                select={[
-                  heapName,
-                  `address-${stackSlot.value.value}`,
-                  "objectRef",
-                ]}
+                select={[heapName, `address-${stackSlot.value.value}`, "elm-0"]}
               />
             </Arrow>
           ) : null

--- a/src/stories/components/GraphLayered.stories.tsx
+++ b/src/stories/components/GraphLayered.stories.tsx
@@ -3,7 +3,7 @@ import { Rect } from "../../rect";
 import { Bluefish } from "../../bluefish";
 import Arrow from "../../arrow";
 import Ref from "../../ref";
-import { GraphLayered } from "../../graphLayered";
+import { GraphLayered, Node, Edge } from "../../graphLayered";
 
 /**
  * Creates a layered graph using [dagre](https://github.com/dagrejs/dagre). The direction of the
@@ -33,52 +33,66 @@ export const FirstStory: Story = {
   },
   render: (props) => (
     <Bluefish>
-      <GraphLayered
-        {...props}
-        edges={[
-          { source: "a", target: "b" },
-          { source: "b", target: "f" },
-          { source: "c", target: "f" },
-          { source: "d", target: "e" },
-          { source: "e", target: "f" },
-        ]}
-      >
-        <Rect
-          name="a"
-          width={144}
-          height={100}
-          fill="LavenderBlush"
-          stroke="#aaa"
-        />
-        <Rect
-          name="b"
-          width={160}
-          height={100}
-          fill="PeachPuff"
-          stroke="#aaa"
-        />
-        <Rect
-          name="c"
-          width={108}
-          height={100}
-          fill="LightSkyBlue"
-          stroke="#aaa"
-        />
-        <Rect
-          name="d"
-          width={168}
-          height={100}
-          fill="PaleGreen"
-          stroke="#aaa"
-        />
-        <Rect name="e" width={144} height={100} fill="Cornsilk" stroke="#aaa" />
-        <Rect
-          name="f"
-          width={121}
-          height={100}
-          fill="MintCream"
-          stroke="#aaa"
-        />
+      <GraphLayered {...props}>
+        <Node id="a">
+          <Rect
+            name="a"
+            width={144}
+            height={100}
+            fill="LavenderBlush"
+            stroke="#aaa"
+          />
+        </Node>
+        <Node id="b">
+          <Rect
+            name="b"
+            width={160}
+            height={100}
+            fill="PeachPuff"
+            stroke="#aaa"
+          />
+        </Node>
+        <Node id="c">
+          <Rect
+            name="c"
+            width={108}
+            height={100}
+            fill="LightSkyBlue"
+            stroke="#aaa"
+          />
+        </Node>
+        <Node id="d">
+          <Rect
+            name="d"
+            width={168}
+            height={100}
+            fill="PaleGreen"
+            stroke="#aaa"
+          />
+        </Node>
+        <Node id="e">
+          <Rect
+            name="e"
+            width={144}
+            height={100}
+            fill="Cornsilk"
+            stroke="#aaa"
+          />
+        </Node>
+        <Node id="f">
+          <Rect
+            name="f"
+            width={121}
+            height={100}
+            fill="MintCream"
+            stroke="#aaa"
+          />
+        </Node>
+        <Edge source="a" target="b" />
+        <Edge source="b" target="f" />
+        <Edge source="c" target="f" />
+        <Edge source="d" target="e" />
+        <Edge source="e" target="f" />
       </GraphLayered>
       <Arrow>
         <Ref select="a" />

--- a/src/withBluefish.tsx
+++ b/src/withBluefish.tsx
@@ -26,20 +26,24 @@ export function withBluefish<ComponentProps>(
     // scenegraph id
     const contextId = useContext(IdContext);
     const genId = createUniqueId();
-    const id = () => props.name ?? contextId() ?? genId;
+    const genScopeId = createUniqueId();
+    // const id = () => props.name ?? contextId() ?? genId;
+    const id = () => contextId() ?? genId;
+    const scopeId = () => props.name ?? genScopeId;
 
     // component scope id
     const [scope, setScope] = useContext(ScopeContext);
-    const scopeId = createMemo(() => {
-      if (props.name !== undefined) {
-        return props.name;
-      }
 
-      // TODO: check if already defined?
+    // TODO: might have to initialize the scope in the store if the scope id was auto-generated
 
-      setScope(genId, {});
-      return genId;
-    });
+    if (scope[scopeId()] === undefined) {
+      setScope(scopeId(), {
+        parent: contextId(),
+        layoutNode: undefined,
+        children: {},
+      });
+    }
+    setScope(scopeId(), "layoutNode", id());
 
     return (
       <ParentScopeIdContext.Provider value={scopeId}>

--- a/src/withBluefish.tsx
+++ b/src/withBluefish.tsx
@@ -3,11 +3,13 @@ import {
   Component,
   JSX,
   createContext,
+  createMemo,
   createUniqueId,
   mergeProps,
   useContext,
 } from "solid-js";
 import { Id } from "./scenegraph";
+import { ParentScopeIdContext, ScopeContext } from "./createName";
 
 export type WithBluefishProps<T = object> = T & {
   name: Id;
@@ -21,17 +23,33 @@ export function withBluefish<ComponentProps>(
   WrappedComponent: Component<WithBluefishProps<ComponentProps>>
 ) {
   return function (props: Omit<ComponentProps, "name"> & { name?: Id }) {
+    // scenegraph id
     const contextId = useContext(IdContext);
     const genId = createUniqueId();
     const id = () => props.name ?? contextId() ?? genId;
 
+    // component scope id
+    const [scope, setScope] = useContext(ScopeContext);
+    const scopeId = createMemo(() => {
+      if (props.name !== undefined) {
+        return props.name;
+      }
+
+      // TODO: check if already defined?
+
+      setScope(genId, {});
+      return genId;
+    });
+
     return (
-      <IdContext.Provider value={id}>
-        <WrappedComponent
-          {...(props as WithBluefishProps<ComponentProps>)}
-          name={id()}
-        />
-      </IdContext.Provider>
+      <ParentScopeIdContext.Provider value={scopeId}>
+        <IdContext.Provider value={id}>
+          <WrappedComponent
+            {...(props as WithBluefishProps<ComponentProps>)}
+            name={id()}
+          />
+        </IdContext.Provider>
+      </ParentScopeIdContext.Provider>
     );
   };
 }

--- a/src/withBluefish.tsx
+++ b/src/withBluefish.tsx
@@ -25,6 +25,7 @@ export function withBluefish<ComponentProps>(
   return function (props: Omit<ComponentProps, "name"> & { name?: Id }) {
     // scenegraph id
     const contextId = useContext(IdContext);
+    const parentScopeId = useContext(ParentScopeIdContext);
     const genId = createUniqueId();
     const genScopeId = createUniqueId();
     // const id = () => props.name ?? contextId() ?? genId;
@@ -38,7 +39,7 @@ export function withBluefish<ComponentProps>(
 
     if (scope[scopeId()] === undefined) {
       setScope(scopeId(), {
-        parent: contextId(),
+        parent: parentScopeId(),
         layoutNode: undefined,
         children: {},
       });


### PR DESCRIPTION
Implements scoped references.

- Introduces `createName` to add a name that is scoped to a component.
- Expands `Ref` selection to be either a single `Id` or an array of an `Id` followed by several `Name`s.

I've also refactored the tree and Python Tutor examples to use scoped references.


# How it works
- We keep around a `Scope` store that maps an id (representing a scope) to a layout node and its child names.
- When someone calls `createName`, we register a new node in the `Scope` dictionary, and add it as a child of the current scope.
- We propagate scopes using `withBluefish`. We also attach a `layoutNode` id to a scope id during the `withBluefish` propagation. The `layoutNode` id is propagating separately, and corresponds to a `Layout` component in the tree hierarchy.
- When we hit a `Ref` node, we follow the path in the `select` field through the `Scope` dictionary to resolve a layout node.