### PR TITLE
feat/fix: implement Stack. fix `total` parameter on StackH and StackV

### DIFF
--- a/src/stack.tsx
+++ b/src/stack.tsx
@@ -1,0 +1,57 @@
+import { withBluefish } from "./withBluefish";
+import {
+  ParentProps,
+  JSX,
+  splitProps,
+  mergeProps,
+  createMemo,
+  createEffect,
+} from "solid-js";
+import { StackArgs, stackLayout } from "./stackLayout";
+import { BBox, Transform, ChildNode } from "./scenegraph";
+import Layout from "./layout";
+
+export type StackProps = ParentProps<StackArgs>;
+
+export const Stack = withBluefish((props: StackProps) => {
+  // if both total and spacing are undefined, default spacing to 10
+  const spacing = createMemo(() => {
+    if (props.total === undefined && props.spacing === undefined) return 10;
+    return props.spacing;
+  });
+
+  props = mergeProps(
+    {
+      get spacing() {
+        return spacing();
+      },
+    },
+    props
+  );
+
+  const layout = (childNodes: ChildNode[]) => {
+    return stackLayout(props)(childNodes);
+  };
+
+  const paint = (paintProps: {
+    bbox: BBox;
+    transform: Transform;
+    children: JSX.Element;
+  }) => {
+    return (
+      <g
+        transform={`translate(${paintProps.transform.translate.x ?? 0}, ${
+          paintProps.transform.translate.y ?? 0
+        })`}
+      >
+        {paintProps.children}
+      </g>
+    );
+  };
+
+  return (
+    <Layout name={props.name} layout={layout} paint={paint}>
+      {props.children}
+    </Layout>
+  );
+});

--- a/src/stackh.tsx
+++ b/src/stackh.tsx
@@ -4,44 +4,20 @@ import withBluefish from "./withBluefish";
 import Layout from "./layout";
 import { BBox, Transform, ChildNode } from "./scenegraph";
 import { AlignmentVertical } from "./align";
+import { Stack } from "./stack";
 
 export type StackHProps = ParentProps<
   Omit<StackArgs, "direction"> & { alignment?: AlignmentVertical }
 >;
 
 export const StackH = withBluefish((props: StackHProps) => {
-  const layout = (childNodes: ChildNode[]) => {
-    const stackProps = mergeProps(
-      {
-        direction: "horizontal" as const,
-        alignment: "centerY" as const,
-        spacing: 10,
-      },
-      props
-    );
-
-    return stackLayout(stackProps)(childNodes);
-  };
-
-  const paint = (paintProps: {
-    bbox: BBox;
-    transform: Transform;
-    children: JSX.Element;
-  }) => {
-    return (
-      <g
-        transform={`translate(${paintProps.transform.translate.x ?? 0}, ${
-          paintProps.transform.translate.y ?? 0
-        })`}
-      >
-        {paintProps.children}
-      </g>
-    );
-  };
-
-  return (
-    <Layout name={props.name} layout={layout} paint={paint}>
-      {props.children}
-    </Layout>
+  const stackProps = mergeProps(
+    {
+      direction: "horizontal" as const,
+      alignment: "centerY" as const,
+    },
+    props
   );
+
+  return <Stack {...stackProps} />;
 });

--- a/src/stackv.tsx
+++ b/src/stackv.tsx
@@ -4,44 +4,20 @@ import withBluefish from "./withBluefish";
 import Layout from "./layout";
 import { BBox, Transform, ChildNode } from "./scenegraph";
 import { AlignmentHorizontal } from "./align";
+import { Stack } from "./stack";
 
 export type StackVProps = ParentProps<
   Omit<StackArgs, "direction"> & { alignment?: AlignmentHorizontal }
 >;
 
 export const StackV = withBluefish((props: StackVProps) => {
-  const layout = (childNodes: ChildNode[]) => {
-    const stackProps = mergeProps(
-      {
-        direction: "vertical" as const,
-        alignment: "centerX" as const,
-        spacing: 10,
-      },
-      props
-    );
-
-    return stackLayout(stackProps)(childNodes);
-  };
-
-  const paint = (paintProps: {
-    bbox: BBox;
-    transform: Transform;
-    children: JSX.Element;
-  }) => {
-    return (
-      <g
-        transform={`translate(${paintProps.transform.translate.x ?? 0}, ${
-          paintProps.transform.translate.y ?? 0
-        })`}
-      >
-        {paintProps.children}
-      </g>
-    );
-  };
-
-  return (
-    <Layout name={props.name} layout={layout} paint={paint}>
-      {props.children}
-    </Layout>
+  const stackProps = mergeProps(
+    {
+      direction: "vertical" as const,
+      alignment: "centerX" as const,
+    },
+    props
   );
+
+  return <Stack {...stackProps} />;
 });

--- a/src/stories/components/Stack.stories.tsx
+++ b/src/stories/components/Stack.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj } from "storybook-solidjs";
+import { Stack } from "../../stack";
+import { Bluefish } from "../../bluefish";
+import Rect from "../../rect";
+
+/**
+ * TODO: write some docs
+ */
+const meta: Meta<typeof Stack> = {
+  title: "Components/Stack",
+  component: Stack,
+  tags: ["autodocs"],
+  argTypes: {
+    alignment: { control: "radio", options: ["left", "centerX", "right"] },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Stack>;
+
+export const Horizontal: Story = {
+  args: {
+    spacing: 20,
+    alignment: "centerY",
+    direction: "horizontal",
+  },
+  render: (props) => {
+    return (
+      <Bluefish>
+        <Stack {...props}>
+          <Rect width={30} height={30} />
+          <Rect width={20} height={20} />
+          <Rect width={50} height={50} />
+        </Stack>
+      </Bluefish>
+    );
+  },
+};
+
+export const Vertical: Story = {
+  args: {
+    spacing: 20,
+    alignment: "centerX",
+    direction: "vertical",
+  },
+  render: (props) => {
+    return (
+      <Bluefish>
+        <Stack {...props}>
+          <Rect width={30} height={30} />
+          <Rect width={20} height={20} />
+          <Rect width={50} height={50} />
+        </Stack>
+      </Bluefish>
+    );
+  },
+};

--- a/src/stories/components/StackH.stories.tsx
+++ b/src/stories/components/StackH.stories.tsx
@@ -38,20 +38,39 @@ export const DefinedSpacing: Story = {
   },
 };
 
-// export const TotalSpacing: Story = {
-//   args: {
-//     total: 80,
-//     alignment: "centerY",
-//   },
-//   render: (props) => {
-//     return (
-//       <Bluefish width={600} height={100}>
-//         <Row {...props}>
-//           <Rect width={30} height={30} />
-//           <Rect width={20} height={20} />
-//           <Rect width={50} height={50} />
-//         </Row>
-//       </Bluefish>
-//     );
-//   },
-// };
+export const TotalSpacing: Story = {
+  args: {
+    total: 110,
+    alignment: "centerY",
+  },
+  render: (props) => {
+    return (
+      <Bluefish>
+        <StackH {...props}>
+          <Rect width={30} height={30} />
+          <Rect width={20} height={20} />
+          <Rect width={50} height={50} />
+        </StackH>
+      </Bluefish>
+    );
+  },
+};
+
+export const TotalAndSpacing: Story = {
+  args: {
+    spacing: 20,
+    total: 500,
+    alignment: "centerY",
+  },
+  render: (props) => {
+    return (
+      <Bluefish>
+        <StackH {...props}>
+          <Rect height={30} />
+          <Rect height={20} />
+          <Rect height={50} />
+        </StackH>
+      </Bluefish>
+    );
+  },
+};

--- a/src/stories/components/StackV.stories.tsx
+++ b/src/stories/components/StackV.stories.tsx
@@ -38,20 +38,39 @@ export const DefinedSpacing: Story = {
   },
 };
 
-// export const TotalSpacing: Story = {
-//   args: {
-//     total: 80,
-//     alignment: "centerY",
-//   },
-//   render: (props) => {
-//     return (
-//       <Bluefish width={600} height={100}>
-//         <Row {...props}>
-//           <Rect width={30} height={30} />
-//           <Rect width={20} height={20} />
-//           <Rect width={50} height={50} />
-//         </Row>
-//       </Bluefish>
-//     );
-//   },
-// };
+export const TotalSpacing: Story = {
+  args: {
+    total: 110,
+    alignment: "centerX",
+  },
+  render: (props) => {
+    return (
+      <Bluefish>
+        <StackV {...props}>
+          <Rect width={30} height={30} />
+          <Rect width={20} height={20} />
+          <Rect width={50} height={50} />
+        </StackV>
+      </Bluefish>
+    );
+  },
+};
+
+export const TotalAndSpacing: Story = {
+  args: {
+    spacing: 20,
+    total: 100,
+    alignment: "centerX",
+  },
+  render: (props) => {
+    return (
+      <Bluefish>
+        <StackV {...props}>
+          <Rect width={30} />
+          <Rect width={20} />
+          <Rect width={50} />
+        </StackV>
+      </Bluefish>
+    );
+  },
+};


### PR DESCRIPTION
closes #35

The problem was that if `spacing` was undefined we would always give it a value. So when a user defined just `total`, the layout would receive both `total` and `spacing`, so it would execute the total+spacing case instead of the total case.