### PR TITLE
fix: #41

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@storybook/addon-interactions": "^7.5.1",
     "@storybook/addon-links": "^7.5.1",
     "@storybook/blocks": "^7.5.1",
+    "@storybook/jest": "^0.2.3",
     "@storybook/test-runner": "^0.13.0",
     "@storybook/testing-library": "^0.2.2",
     "@types/dagre": "^0.7.51",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,6 +49,9 @@ devDependencies:
   '@storybook/blocks':
     specifier: ^7.5.1
     version: 7.5.1(react-dom@18.2.0)(react@18.2.0)
+  '@storybook/jest':
+    specifier: ^0.2.3
+    version: 0.2.3(jest@28.1.3)
   '@storybook/test-runner':
     specifier: ^0.13.0
     version: 0.13.0(@types/node@20.3.3)
@@ -120,6 +123,10 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /@adobe/css-tools@4.3.1:
+    resolution: {integrity: sha512-/62yikz7NLScCGAAST5SHdnjaDJQBDq0M2muyRTpf2VQhw6StBg2ALiu73zSJQ4fMVLA+0uBhBHAle7Wg+2kSg==}
+    dev: true
+
   /@ampproject/remapping@2.2.1:
     resolution: {integrity: sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==}
     engines: {node: '>=6.0.0'}
@@ -148,6 +155,14 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/highlight': 7.22.5
+    dev: true
+
+  /@babel/code-frame@7.23.4:
+    resolution: {integrity: sha512-r1IONyb6Ia+jYR2vvIDhdWdlTGhqbBoFqLTQidzZ4kepUFH15ejXvFHxCVbtl7BOXIudsIubf4E81xeA3h3IXA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/highlight': 7.23.4
+      chalk: 2.4.2
     dev: true
 
   /@babel/compat-data@7.22.20:
@@ -221,6 +236,16 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.22.5
+      '@jridgewell/gen-mapping': 0.3.3
+      '@jridgewell/trace-mapping': 0.3.18
+      jsesc: 2.5.2
+    dev: true
+
+  /@babel/generator@7.23.4:
+    resolution: {integrity: sha512-esuS49Cga3HcThFNebGhlgsrVLkvhqvYDTzgjfFFlHJcIfLe5jFmRRfCQ1KuBfc4Jrtn3ndLgKWAKjBE+IraYQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.23.4
       '@jridgewell/gen-mapping': 0.3.3
       '@jridgewell/trace-mapping': 0.3.18
       jsesc: 2.5.2
@@ -386,6 +411,14 @@ packages:
       '@babel/types': 7.22.5
     dev: true
 
+  /@babel/helper-function-name@7.23.0:
+    resolution: {integrity: sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/template': 7.22.15
+      '@babel/types': 7.23.4
+    dev: true
+
   /@babel/helper-hoist-variables@7.22.5:
     resolution: {integrity: sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==}
     engines: {node: '>=6.9.0'}
@@ -548,6 +581,11 @@ packages:
     engines: {node: '>=6.9.0'}
     dev: true
 
+  /@babel/helper-string-parser@7.23.4:
+    resolution: {integrity: sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
   /@babel/helper-validator-identifier@7.22.20:
     resolution: {integrity: sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==}
     engines: {node: '>=6.9.0'}
@@ -617,6 +655,15 @@ packages:
       js-tokens: 4.0.0
     dev: true
 
+  /@babel/highlight@7.23.4:
+    resolution: {integrity: sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-validator-identifier': 7.22.20
+      chalk: 2.4.2
+      js-tokens: 4.0.0
+    dev: true
+
   /@babel/parser@7.22.16:
     resolution: {integrity: sha512-+gPfKv8UWeKKeJTUxe59+OobVcrYHETCsORl61EmSkmgymguYk/X5bp7GuUIXaFsc6y++v8ZxPsLSSuujqDphA==}
     engines: {node: '>=6.0.0'}
@@ -631,6 +678,14 @@ packages:
     hasBin: true
     dependencies:
       '@babel/types': 7.22.5
+    dev: true
+
+  /@babel/parser@7.23.4:
+    resolution: {integrity: sha512-vf3Xna6UEprW+7t6EtOmFpHNAuxw3xqPZghy+brsnusscJRW5BMUzzHZc5ICjULee81WeUV2jjakG09MDglJXQ==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+    dependencies:
+      '@babel/types': 7.23.4
     dev: true
 
   /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.22.15(@babel/core@7.22.6):
@@ -1958,6 +2013,24 @@ packages:
       - supports-color
     dev: true
 
+  /@babel/traverse@7.23.4:
+    resolution: {integrity: sha512-IYM8wSUwunWTB6tFC2dkKZhxbIjHoWemdK+3f8/wq8aKhbUscxD5MX72ubd90fxvFknaLPeGw5ycU84V1obHJg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/code-frame': 7.23.4
+      '@babel/generator': 7.23.4
+      '@babel/helper-environment-visitor': 7.22.20
+      '@babel/helper-function-name': 7.23.0
+      '@babel/helper-hoist-variables': 7.22.5
+      '@babel/helper-split-export-declaration': 7.22.6
+      '@babel/parser': 7.23.4
+      '@babel/types': 7.23.4
+      debug: 4.3.4
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/types@7.22.19:
     resolution: {integrity: sha512-P7LAw/LbojPzkgp5oznjE6tQEIWbp4PkkfrZDINTro9zgBRtI324/EYsiSI7lhPbpIQ+DCeR2NNmMWANGGfZsg==}
     engines: {node: '>=6.9.0'}
@@ -1973,6 +2046,15 @@ packages:
     dependencies:
       '@babel/helper-string-parser': 7.22.5
       '@babel/helper-validator-identifier': 7.22.5
+      to-fast-properties: 2.0.0
+    dev: true
+
+  /@babel/types@7.23.4:
+    resolution: {integrity: sha512-7uIFwVYpoplT5jp/kVv6EF93VaJ8H+Yn5IczYiaAi98ajzjfoZfslet/e0sLh+wVBjb2qqIut1b0S26VSafsSQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-string-parser': 7.23.4
+      '@babel/helper-validator-identifier': 7.22.20
       to-fast-properties: 2.0.0
     dev: true
 
@@ -4029,8 +4111,8 @@ packages:
       - supports-color
     dev: true
 
-  /@storybook/builder-vite@7.6.0-alpha.3(typescript@4.9.5)(vite@4.3.9):
-    resolution: {integrity: sha512-0Rj4Myfq9nbIyDifyM1WYIszKDsfYrKKoNaEdUfukG0kZQHo/d+RebgIh4/TgSo321/pQ5rYrFFBj05U7/YjrA==}
+  /@storybook/builder-vite@7.6.0-alpha.6(typescript@4.9.5)(vite@4.3.9):
+    resolution: {integrity: sha512-yOf0CHi9w/e7vZIkaQUMMAUnX4EYTnKQSyIX5nxmz+c6V2IZxR1MvzJ+FEds83rn5L6aNTEMOYq0uQPDSpiBPA==}
     peerDependencies:
       '@preact/preset-vite': '*'
       typescript: '>= 4.3.x'
@@ -4044,14 +4126,14 @@ packages:
       vite-plugin-glimmerx:
         optional: true
     dependencies:
-      '@storybook/channels': 7.6.0-alpha.3
-      '@storybook/client-logger': 7.6.0-alpha.3
-      '@storybook/core-common': 7.6.0-alpha.3
-      '@storybook/csf-plugin': 7.6.0-alpha.3
-      '@storybook/node-logger': 7.6.0-alpha.3
-      '@storybook/preview': 7.6.0-alpha.3
-      '@storybook/preview-api': 7.6.0-alpha.3
-      '@storybook/types': 7.6.0-alpha.3
+      '@storybook/channels': 7.6.0-alpha.6
+      '@storybook/client-logger': 7.6.0-alpha.6
+      '@storybook/core-common': 7.6.0-alpha.6
+      '@storybook/csf-plugin': 7.6.0-alpha.6
+      '@storybook/node-logger': 7.6.0-alpha.6
+      '@storybook/preview': 7.6.0-alpha.6
+      '@storybook/preview-api': 7.6.0-alpha.6
+      '@storybook/types': 7.6.0-alpha.6
       '@types/find-cache-dir': 3.2.1
       browser-assert: 1.2.1
       es-module-lexer: 0.9.3
@@ -4089,11 +4171,11 @@ packages:
       tiny-invariant: 1.3.1
     dev: true
 
-  /@storybook/channels@7.6.0-alpha.3:
-    resolution: {integrity: sha512-fhVcVzJCZmMVX2eQSXZ53M+EmYy9eYc3DQCwW684mBXNi0NtDwqdZExzGrhk6oqaCCFdBUgaOoKfCyWMwP2jsA==}
+  /@storybook/channels@7.6.0-alpha.6:
+    resolution: {integrity: sha512-QoLtN3mPqgSvWTO59XM//1T3ttDyUtWI2Q5qeQMvOq8H4i4rSGpCkywN6OPVivAgCiHSKSCC9C3yE/xISzjf1g==}
     dependencies:
-      '@storybook/client-logger': 7.6.0-alpha.3
-      '@storybook/core-events': 7.6.0-alpha.3
+      '@storybook/client-logger': 7.6.0-alpha.6
+      '@storybook/core-events': 7.6.0-alpha.6
       '@storybook/global': 5.0.0
       qs: 6.11.2
       telejson: 7.2.0
@@ -4164,8 +4246,8 @@ packages:
       '@storybook/global': 5.0.0
     dev: true
 
-  /@storybook/client-logger@7.6.0-alpha.3:
-    resolution: {integrity: sha512-QWLLAuwaTgwdbQ9hJc6sHVjFIH+dh7E6C63MwxWaAN39+nxKYln25xcZaf3bpNvtwHWU8H5ULyE9Q2vGdURMuw==}
+  /@storybook/client-logger@7.6.0-alpha.6:
+    resolution: {integrity: sha512-ptcacMUCbcQecAkh2LsPFvvEpgsPLOVeMLjrSBahqQhaJGb9YL7N9jZ+UTcq0iK9vjf7B7KFvBcWrazHRROeTg==}
     dependencies:
       '@storybook/global': 5.0.0
     dev: true
@@ -4276,12 +4358,12 @@ packages:
       - supports-color
     dev: true
 
-  /@storybook/core-common@7.6.0-alpha.3:
-    resolution: {integrity: sha512-rzU57RvVt7cCOpX48draTHvs0xrSTKyS1QwbvesIGeoKCGTDieZ5sbbNToUNjf6XZcmS7mJGjNKwMaNT2mGKfA==}
+  /@storybook/core-common@7.6.0-alpha.6:
+    resolution: {integrity: sha512-HCq1ONotCK2yLC9XF/o4mXblZ07S1GKifj2bupavln1iQacgIRYY8/Lq7AWsBJMgmOYTl+Mx0CeLVjtEXij8uw==}
     dependencies:
-      '@storybook/core-events': 7.6.0-alpha.3
-      '@storybook/node-logger': 7.6.0-alpha.3
-      '@storybook/types': 7.6.0-alpha.3
+      '@storybook/core-events': 7.6.0-alpha.6
+      '@storybook/node-logger': 7.6.0-alpha.6
+      '@storybook/types': 7.6.0-alpha.6
       '@types/find-cache-dir': 3.2.1
       '@types/node': 18.18.5
       '@types/node-fetch': 2.6.5
@@ -4319,8 +4401,8 @@ packages:
       ts-dedent: 2.2.0
     dev: true
 
-  /@storybook/core-events@7.6.0-alpha.3:
-    resolution: {integrity: sha512-9Jz/VimUPNTy9450A+Wv2ILiCbz7tSej8A4EZPB4vW8hi4sOy01FmV04eD75Q6MmnSFRBzmt9Si3Z9SSRTHJ9w==}
+  /@storybook/core-events@7.6.0-alpha.6:
+    resolution: {integrity: sha512-MOWI+AD4F4/bvwjVZtPX9lNLMJEiBhPn/lzS50OY4CQmARsp4Obnr/sH6VnoLLAou655OWGQYvnOjritwved+A==}
     dependencies:
       ts-dedent: 2.2.0
     dev: true
@@ -4385,10 +4467,10 @@ packages:
       - supports-color
     dev: true
 
-  /@storybook/csf-plugin@7.6.0-alpha.3:
-    resolution: {integrity: sha512-my71D4BlgO8WUR9JNvh0KrOy29Z4wpqAkQ3seG3PEurk+DP17t5r+vfG/PogTAFM1yEZiQbRNBrIeR+2/e+JPw==}
+  /@storybook/csf-plugin@7.6.0-alpha.6:
+    resolution: {integrity: sha512-b86z3sv8lkEVrg3YYYfgrWc4tTvNnxFMDv3bHkP2FkuzkPKUs3EAM7yXHrr+sZ/0ThDXitLfrIBnAD3YIHCGlg==}
     dependencies:
-      '@storybook/csf-tools': 7.6.0-alpha.3
+      '@storybook/csf-tools': 7.6.0-alpha.6
       unplugin: 1.5.0
     transitivePeerDependencies:
       - supports-color
@@ -4426,15 +4508,15 @@ packages:
       - supports-color
     dev: true
 
-  /@storybook/csf-tools@7.6.0-alpha.3:
-    resolution: {integrity: sha512-cG2asWqrSQ2W/RPM0lNJxS4KR1wasRIOHyOBLk4gOaNpKPXP+G2UGjaxVrFfwVQR3Wn65Nj/L0T8/Z+5j+4ziA==}
+  /@storybook/csf-tools@7.6.0-alpha.6:
+    resolution: {integrity: sha512-qHkwe5vNB9kmqN9zux7d3brtLAJugEa2JDBVbTQS3fVbUYRjL5WnTYOfuPzxEyYtaUTpVJMZjs2rgRAixN3yzQ==}
     dependencies:
-      '@babel/generator': 7.22.15
-      '@babel/parser': 7.22.16
-      '@babel/traverse': 7.22.20
-      '@babel/types': 7.22.19
+      '@babel/generator': 7.23.4
+      '@babel/parser': 7.23.4
+      '@babel/traverse': 7.23.4
+      '@babel/types': 7.23.4
       '@storybook/csf': 0.1.1
-      '@storybook/types': 7.6.0-alpha.3
+      '@storybook/types': 7.6.0-alpha.6
       fs-extra: 11.1.1
       recast: 0.23.4
       ts-dedent: 2.2.0
@@ -4472,6 +4554,12 @@ packages:
       - supports-color
     dev: true
 
+  /@storybook/expect@28.1.3-5:
+    resolution: {integrity: sha512-lS1oJnY1qTAxnH87C765NdfvGhksA6hBcbUVI5CHiSbNsEtr456wtg/z+dT9XlPriq1D5t2SgfNL9dBAoIGyIA==}
+    dependencies:
+      '@types/jest': 28.1.3
+    dev: true
+
   /@storybook/global@5.0.0:
     resolution: {integrity: sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==}
     dev: true
@@ -4484,6 +4572,19 @@ packages:
       '@storybook/core-events': 7.5.1
       '@storybook/global': 5.0.0
       '@storybook/preview-api': 7.5.1
+    dev: true
+
+  /@storybook/jest@0.2.3(jest@28.1.3):
+    resolution: {integrity: sha512-ov5izrmbAFObzKeh9AOC5MlmFxAcf0o5i6YFGae9sDx6DGh6alXsRM+chIbucVkUwVHVlSzdfbLDEFGY/ShaYw==}
+    dependencies:
+      '@storybook/expect': 28.1.3-5
+      '@testing-library/jest-dom': 6.1.4(@types/jest@28.1.3)(jest@28.1.3)
+      '@types/jest': 28.1.3
+      jest-mock: 27.5.1
+    transitivePeerDependencies:
+      - '@jest/globals'
+      - jest
+      - vitest
     dev: true
 
   /@storybook/manager-api@7.5.1(react-dom@18.2.0)(react@18.2.0):
@@ -4527,8 +4628,8 @@ packages:
     resolution: {integrity: sha512-xRMdL5YPe8C9sgJ1R0QD3YbiLjDGrfQk91+GplRD8N9FVCT5dki55Bv5Kp0FpemLYYg6uxAZL5nHmsZHKDKQoA==}
     dev: true
 
-  /@storybook/node-logger@7.6.0-alpha.3:
-    resolution: {integrity: sha512-lPVZjDImAR912pt1VYlQcMKBO3I8/4VYae+As69f9igDf1dfYv+7mDjGjLw97g7q3WEK96ltUD9VD3bntqSM4g==}
+  /@storybook/node-logger@7.6.0-alpha.6:
+    resolution: {integrity: sha512-SiBVkOLQa/mxffveHKwipEaA5en4QPQ8C3yk5Rbx/caU+RzLFFh0ctfGcxoP6Jcto5WE0Clkzs+9+hHxIDJRcA==}
     dev: true
 
   /@storybook/postinstall@7.5.1:
@@ -4573,15 +4674,15 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/preview-api@7.6.0-alpha.3:
-    resolution: {integrity: sha512-V3sxeaI5wM6PS5Ief5dnPPMzCM0HHWOgCCCRZJR2bIdDPB7sfBcvVsO/75O31IKUKtmJkyRe8oWimYCdUR1p2g==}
+  /@storybook/preview-api@7.6.0-alpha.6:
+    resolution: {integrity: sha512-cNa+ECEUmElyGXn17cgn89JWA0flYuLvAfhnDIuGPsHZkNe2DkT7ci3cc8SXYpTn0+NS6G+tdhkgA+EuWAjaaw==}
     dependencies:
-      '@storybook/channels': 7.6.0-alpha.3
-      '@storybook/client-logger': 7.6.0-alpha.3
-      '@storybook/core-events': 7.6.0-alpha.3
+      '@storybook/channels': 7.6.0-alpha.6
+      '@storybook/client-logger': 7.6.0-alpha.6
+      '@storybook/core-events': 7.6.0-alpha.6
       '@storybook/csf': 0.1.1
       '@storybook/global': 5.0.0
-      '@storybook/types': 7.6.0-alpha.3
+      '@storybook/types': 7.6.0-alpha.6
       '@types/qs': 6.9.8
       dequal: 2.0.3
       lodash: 4.17.21
@@ -4592,8 +4693,8 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/preview@7.6.0-alpha.3:
-    resolution: {integrity: sha512-02rtofmlftFYqULUOAPmXTk7vCrZk1uSdEoYnCAvTeOw5ZbBz/KZi10jWSdjRxw8xiC0miVb0wvZEBJ+Dm+5Zw==}
+  /@storybook/preview@7.6.0-alpha.6:
+    resolution: {integrity: sha512-LwwSPrxE6787uCA7EyWT1eesPY9rd2FmZoC+o8y9xubItZAHaO2RSLaMtYdaTXoDZQIySWP6LLAjU44ZcrjVeA==}
     dev: true
 
   /@storybook/react-dom-shim@7.5.1(react-dom@18.2.0)(react@18.2.0):
@@ -4716,10 +4817,10 @@ packages:
       file-system-cache: 2.3.0
     dev: true
 
-  /@storybook/types@7.6.0-alpha.3:
-    resolution: {integrity: sha512-NIMfDvgMumomKmbss6opqKuHQkZOmKB1MWt7FkrpkbheVJin1h3Ve0aoIH421ANCXi7UaswaEWanOCwHl3DZUg==}
+  /@storybook/types@7.6.0-alpha.6:
+    resolution: {integrity: sha512-tnIcX4fWrsON6NatmpMys/8wbnVojERygqLuY9UzdBw9eG/gMq4jlEj2CaRDSZw4TS5/RhTBM6jdsfc5tgU7eg==}
     dependencies:
-      '@storybook/channels': 7.6.0-alpha.3
+      '@storybook/channels': 7.6.0-alpha.6
       '@types/babel__core': 7.20.1
       '@types/express': 4.17.17
       file-system-cache: 2.3.0
@@ -4868,6 +4969,36 @@ packages:
       pretty-format: 27.5.1
     dev: true
 
+  /@testing-library/jest-dom@6.1.4(@types/jest@28.1.3)(jest@28.1.3):
+    resolution: {integrity: sha512-wpoYrCYwSZ5/AxcrjLxJmCU6I5QAJXslEeSiMQqaWmP2Kzpd1LvF/qxmAIW2qposULGWq2gw30GgVNFLSc2Jnw==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+    peerDependencies:
+      '@jest/globals': '>= 28'
+      '@types/jest': '>= 28'
+      jest: '>= 28'
+      vitest: '>= 0.32'
+    peerDependenciesMeta:
+      '@jest/globals':
+        optional: true
+      '@types/jest':
+        optional: true
+      jest:
+        optional: true
+      vitest:
+        optional: true
+    dependencies:
+      '@adobe/css-tools': 4.3.1
+      '@babel/runtime': 7.22.15
+      '@types/jest': 28.1.3
+      aria-query: 5.1.3
+      chalk: 3.0.0
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.5.16
+      jest: 28.1.3(@types/node@20.3.3)
+      lodash: 4.17.21
+      redent: 3.0.0
+    dev: true
+
   /@testing-library/user-event@14.4.3(@testing-library/dom@9.3.3):
     resolution: {integrity: sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==}
     engines: {node: '>=12', npm: '>=6'}
@@ -5005,6 +5136,13 @@ packages:
     resolution: {integrity: sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==}
     dependencies:
       '@types/istanbul-lib-report': 3.0.0
+    dev: true
+
+  /@types/jest@28.1.3:
+    resolution: {integrity: sha512-Tsbjk8Y2hkBaY/gJsataeb4q9Mubw9EOz7+4RjPkzD5KjTvHHs7cpws22InaoXxAVAhF5HfFbzJjo6oKWqSZLw==}
+    dependencies:
+      jest-matcher-utils: 28.1.3
+      pretty-format: 28.1.3
     dev: true
 
   /@types/json-schema@7.0.13:
@@ -5939,6 +6077,14 @@ packages:
       supports-color: 5.5.0
     dev: true
 
+  /chalk@3.0.0:
+    resolution: {integrity: sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==}
+    engines: {node: '>=8'}
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+    dev: true
+
   /chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -6217,6 +6363,10 @@ packages:
   /css-unit-converter@1.1.2:
     resolution: {integrity: sha512-IiJwMC8rdZE0+xiEZHeru6YoONC4rfPMqGm2W85jMIbkFvv5nFTwJVFHam2eFrN6txmoUYFAFXiv8ICVeTO0MA==}
     dev: false
+
+  /css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+    dev: true
 
   /csstype@3.1.2:
     resolution: {integrity: sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==}
@@ -9055,6 +9205,11 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
+  /min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
+    dev: true
+
   /minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
     dependencies:
@@ -9942,6 +10097,14 @@ packages:
       tslib: 2.6.2
     dev: true
 
+  /redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
+    dev: true
+
   /reduce-css-calc@2.1.8:
     resolution: {integrity: sha512-8liAVezDmUcH+tdzoEGrhfbGcP7nOV4NkGE3a74+qqvE7nt9i4sKLGBuZNOnpI4WiGksiNPklZxva80061QiPg==}
     dependencies:
@@ -10448,7 +10611,7 @@ packages:
     resolution: {integrity: sha512-dD+VMYC5fBBQNesVb+mjB0LOkZIf100SQFbjAt9/sDstNUvc5ce3yZwLYXzgcOc7jcSMkrBu/cZNRzEM4YIAyw==}
     engines: {node: ^14.18 || >=16}
     dependencies:
-      '@storybook/builder-vite': 7.6.0-alpha.3(typescript@4.9.5)(vite@4.3.9)
+      '@storybook/builder-vite': 7.6.0-alpha.6(typescript@4.9.5)(vite@4.3.9)
     transitivePeerDependencies:
       - '@preact/preset-vite'
       - encoding
@@ -10578,6 +10741,13 @@ packages:
   /strip-final-newline@2.0.0:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
     engines: {node: '>=6'}
+    dev: true
+
+  /strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      min-indent: 1.0.1
     dev: true
 
   /strip-json-comments@3.1.1:

--- a/src/layout.tsx
+++ b/src/layout.tsx
@@ -48,7 +48,9 @@ export const Layout: Component<LayoutProps> = (props) => {
     createChildRepr,
   } = UNSAFE_useScenegraph();
 
-  createNode(props.name, parentId);
+  createRenderEffect(() => {
+    createNode(props.name, parentId);
+  });
 
   // evaluate the child props before running the effect so that children's layout functions are
   // called before the parent's layout function

--- a/src/ref.tsx
+++ b/src/ref.tsx
@@ -1,4 +1,10 @@
-import { Component, createEffect, useContext } from "solid-js";
+import {
+  Component,
+  createEffect,
+  createRenderEffect,
+  onCleanup,
+  useContext,
+} from "solid-js";
 import { Id, UNSAFE_useScenegraph, ParentIDContext } from "./scenegraph";
 import withBluefish from "./withBluefish";
 import { Name, Scope, ScopeContext } from "./createName";
@@ -73,27 +79,26 @@ export const resolveSelection = (
 };
 
 export const Ref = withBluefish((props: RefProps) => {
-  const { name, select } = props;
-
   const parentId = useContext(ParentIDContext);
   const [scope] = useContext(ScopeContext);
-  const { createRef, getBBox } = UNSAFE_useScenegraph();
+  const { createRef } = UNSAFE_useScenegraph();
 
   if (parentId === null) {
     throw new Error("Ref must be a child of a Layout");
   }
 
-  const normalizedSelection = normalizeSelection(select);
-
   // TODO: what do we do if the layout node isn't defined?
-  createRef(name, resolveSelection(scope, normalizedSelection), parentId);
+  createRenderEffect(() => {
+    const normalizedSelection = normalizeSelection(props.select);
 
-  // touch the refId's bbox to ensure ref is resolved immediately
-  // createEffect(() => {
-  //   console.log("ref", props.id, props.refId);
-  //   getBBox(id);
-  //   console.log("ref", props.id, JSON.parse(JSON.stringify(getBBox(id))));
-  // });
+    createRef(
+      props.name,
+      resolveSelection(scope, normalizedSelection),
+      parentId
+    );
+
+    // TODO: cleanup
+  });
 
   return <></>;
 });

--- a/src/stories/41.stories.tsx
+++ b/src/stories/41.stories.tsx
@@ -1,0 +1,100 @@
+import { Meta, StoryObj } from "storybook-solidjs";
+import Bluefish from "../bluefish";
+import Group from "../group";
+import Rect from "../rect";
+import Distribute from "../distribute";
+import Align from "../align";
+import Ref from "../ref";
+import { createSignal } from "solid-js";
+import Background from "../background";
+import { StackH } from "../stackh";
+import { Text } from "../text";
+import Circle from "../circle";
+import Arrow from "../arrow";
+import { within, userEvent } from "@storybook/testing-library";
+
+const meta: Meta = {
+  title: "Regression/#41",
+};
+
+export default meta;
+type Story = StoryObj;
+
+export const App: Story = {
+  name: "#41",
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole("button"));
+  },
+  render: () => {
+    const [planet, setPlanet] = createSignal("mercury");
+
+    const handler = () => {
+      if (planet() == "mercury") {
+        setPlanet("venus");
+      } else if (planet() == "venus") {
+        setPlanet("earth");
+      } else if (planet() == "earth") {
+        setPlanet("mars");
+      } else {
+        setPlanet("mercury");
+      }
+    };
+
+    return (
+      <>
+        <button onClick={handler}>Click Me</button>
+        <div>Current planet: {planet()}</div>
+        <div>
+          <Bluefish>
+            <Background padding={20}>
+              <StackH spacing={50}>
+                <Circle
+                  name="mercury"
+                  r={15}
+                  fill="#EBE3CF"
+                  stroke-width={3}
+                  stroke="black"
+                />
+                <Circle
+                  name="venus"
+                  r={36}
+                  fill="#DC933C"
+                  stroke-width={3}
+                  stroke="black"
+                />
+                <Circle
+                  name="earth"
+                  r={38}
+                  fill="#179DD7"
+                  stroke-width={3}
+                  stroke="black"
+                />
+                <Circle
+                  name="mars"
+                  r={21}
+                  fill="#F1CF8E"
+                  stroke-width={3}
+                  stroke="black"
+                />
+              </StackH>
+            </Background>
+            <Align alignment="centerX">
+              <Text name="label">{planet()}</Text>
+              <Ref select={planet()} />
+            </Align>
+            <Distribute direction="vertical" spacing={60}>
+              <Ref select="label" />
+              <Ref select={planet()} />
+            </Distribute>
+            <Arrow>
+              <Ref select="label" />
+              <Ref select={planet()} />
+            </Arrow>
+          </Bluefish>
+        </div>
+      </>
+    );
+  },
+};


### PR DESCRIPTION
Previously, layout and ref nodes were not added reactively, so the scenegraph wouldn't update if it was changed. This PR puts the layout node and ref creations in `createRenderEffect`s.

Note: `createEffect` doesn't work b/c the first run of `createEffect` happens after the DOM has rendered, which is too late. `createRenderEffect` executes more eagerly on first run.