### PR TITLE
feat: Stronger BBox Inference

### DIFF
--- a/src/align.tsx
+++ b/src/align.tsx
@@ -126,7 +126,7 @@ export const Align = withBluefish((props: AlignProps) => {
 
     // TODO: should be able to filter by ownership instead
     const verticalValueArr = verticalPlaceables
-      .filter(([placeable, _]) => placeable!.owned.y)
+      .filter(([placeable, _]) => placeable!.owned.top)
       .map(([placeable, alignment]) => {
         return [
           placeable,
@@ -144,7 +144,7 @@ export const Align = withBluefish((props: AlignProps) => {
       verticalValueArr.length === 0 ? 0 : (verticalValueArr[0][1] as number);
 
     const horizontalValueArr = horizontalPlaceables
-      .filter(([placeable, _]) => placeable!.owned.x)
+      .filter(([placeable, _]) => placeable!.owned.left)
       .map(([placeable, alignment]) => {
         return [
           placeable,
@@ -163,7 +163,7 @@ export const Align = withBluefish((props: AlignProps) => {
         : (horizontalValueArr[0][1] as number);
 
     for (const [placeable, alignment] of verticalPlaceables) {
-      if (placeable!.owned.y) continue;
+      if (placeable!.owned.top) continue;
       if (alignment === "top") {
         placeable!.bbox.top = verticalValue;
       } else if (alignment === "centerY") {
@@ -178,7 +178,7 @@ export const Align = withBluefish((props: AlignProps) => {
     }
 
     for (const [placeable, alignment] of horizontalPlaceables) {
-      if (placeable!.owned.x) continue;
+      if (placeable!.owned.left) continue;
       if (alignment === "left") {
         placeable!.bbox.left = horizontalValue;
       } else if (alignment === "centerX") {

--- a/src/align.tsx
+++ b/src/align.tsx
@@ -167,7 +167,24 @@ export const Align = withBluefish((props: AlignProps) => {
           y: maybeSub(props.y, bbox.top),
         },
       },
-      bbox,
+      bbox: {
+        left:
+          horizontalAlignment(props.alignment) !== undefined
+            ? bbox.left
+            : undefined,
+        width:
+          horizontalAlignment(props.alignment) !== undefined
+            ? bbox.width
+            : undefined,
+        top:
+          verticalAlignment(props.alignment) !== undefined
+            ? bbox.top
+            : undefined,
+        height:
+          verticalAlignment(props.alignment) !== undefined
+            ? bbox.height
+            : undefined,
+      },
     };
   };
 

--- a/src/align.tsx
+++ b/src/align.tsx
@@ -96,7 +96,7 @@ export type AlignProps = ParentProps<{
   name: Id;
   x?: number;
   y?: number;
-  alignment?: Alignment2D | Alignment1D;
+  alignment: Alignment2D | Alignment1D;
 }>;
 
 export const Align = withBluefish((props: AlignProps) => {
@@ -108,93 +108,54 @@ export const Align = withBluefish((props: AlignProps) => {
       debugger;
     }
 
-    const verticalAlignments = childNodes
+    const alignments = childNodes
       .map((m) => /* m.guidePrimary ?? */ props.alignment)
-      .map((alignment) => maybe(alignment, verticalAlignment));
+      .map((alignment) => splitAlignment(alignment));
 
-    const horizontalAlignments = childNodes
-      .map((m) => /* m.guidePrimary ?? */ props.alignment)
-      .map((alignment) => maybe(alignment, horizontalAlignment));
+    // horizontal
+    const horizontalPlaceables = _.zip(childNodes, alignments)
+      .filter(([placeable, alignment]) => alignment![0] !== undefined)
+      .map(([placeable, alignment]) => [placeable, alignment![0]]) as [
+      ChildNode,
+      AlignmentVertical
+    ][];
 
-    const verticalPlaceables = _.zip(childNodes, verticalAlignments).filter(
-      ([placeable, alignment]) => alignment !== undefined
-    );
-
-    const horizontalPlaceables = _.zip(childNodes, horizontalAlignments).filter(
-      ([placeable, alignment]) => alignment !== undefined
-    );
-
-    // TODO: should be able to filter by ownership instead
-    const verticalValueArr = verticalPlaceables
-      .filter(([placeable, _]) => placeable!.owned.top)
-      .map(([placeable, alignment]) => {
-        return [
-          placeable,
-          alignment !== undefined ? placeable!.bbox[alignment] : undefined,
-        ];
-      })
+    const existingHorizontalPositions = horizontalPlaceables
       .filter(
-        ([placeable, value]) =>
-          // scenegraph[placeable!].transformOwners.translate.y !== id &&
-          value !== undefined
-      );
-
-    // TODO: we should probably make it so that the default value depends on the x & y props
-    const verticalValue =
-      verticalValueArr.length === 0 ? 0 : (verticalValueArr[0][1] as number);
-
-    const horizontalValueArr = horizontalPlaceables
-      .filter(([placeable, _]) => placeable!.owned.left)
+        ([placeable, alignment]) => placeable!.owned[alignment as BBox.Dim]
+      )
       .map(([placeable, alignment]) => {
-        return [
-          placeable,
-          alignment !== undefined ? placeable!.bbox[alignment] : undefined,
-        ];
-      })
-      .filter(
-        ([placeable, value]) =>
-          // scenegraph[placeable!].transformOwners.translate.x !== id &&
-          value !== undefined
-      );
+        return [placeable!, placeable!.bbox[alignment as BBox.Dim]!];
+      }) satisfies [ChildNode, number][];
 
-    const horizontalValue =
-      horizontalValueArr.length === 0
-        ? 0
-        : (horizontalValueArr[0][1] as number);
-
-    for (const [placeable, alignment] of verticalPlaceables) {
-      if (placeable!.owned.top) continue;
-      if (alignment === "top") {
-        placeable!.bbox.top = verticalValue;
-      } else if (alignment === "centerY") {
-        const height = placeable!.bbox.height;
-        if (height === undefined) {
-          continue;
-        }
-        placeable!.bbox.top = verticalValue - height / 2;
-      } else if (alignment === "bottom") {
-        placeable!.bbox.top = verticalValue - placeable!.bbox.height!;
-      }
-    }
+    const defaultHorizontalValue = existingHorizontalPositions[0]?.[1] ?? 0;
 
     for (const [placeable, alignment] of horizontalPlaceables) {
-      if (placeable!.owned.left) continue;
-      if (alignment === "left") {
-        placeable!.bbox.left = horizontalValue;
-      } else if (alignment === "centerX") {
-        const width = placeable!.bbox.width;
-        if (width === undefined) {
-          continue;
-        }
-        placeable!.bbox.left = horizontalValue - width / 2;
-      } else if (alignment === "right") {
-        // placeable!.right = horizontalValue;
-        const width = placeable!.bbox.width;
-        if (width === undefined) {
-          continue;
-        }
-        placeable!.bbox.left = horizontalValue - width;
-      }
+      if (placeable!.owned[alignment as BBox.Dim]) continue;
+      placeable!.bbox[alignment as BBox.Dim] = defaultHorizontalValue;
+    }
+
+    // vertical
+    const verticalPlaceables = _.zip(childNodes, alignments)
+      .filter(([placeable, alignment]) => alignment![1] !== undefined)
+      .map(([placeable, alignment]) => [placeable, alignment![1]]) as [
+      ChildNode,
+      AlignmentHorizontal
+    ][];
+
+    const existingVerticalPositions = verticalPlaceables
+      .filter(
+        ([placeable, alignment]) => placeable!.owned[alignment as BBox.Dim]
+      )
+      .map(([placeable, alignment]) => {
+        return [placeable!, placeable!.bbox[alignment as BBox.Dim]!];
+      }) satisfies [ChildNode, number][];
+
+    const defaultVerticalValue = existingVerticalPositions[0]?.[1] ?? 0;
+
+    for (const [placeable, alignment] of verticalPlaceables) {
+      if (placeable!.owned[alignment as BBox.Dim]) continue;
+      placeable!.bbox[alignment as BBox.Dim] = defaultVerticalValue;
     }
 
     const bbox = BBox.from(childNodes.map((childNode) => childNode.bbox));

--- a/src/background.tsx
+++ b/src/background.tsx
@@ -35,11 +35,11 @@ export const Background = withBluefish((props: BackgroundProps) => {
 
     let left: number;
     let top: number;
-    if (!backgroundChild.owned.x) {
+    if (!backgroundChild.owned.left) {
       // infer x from rest
 
       const lefts = rest
-        .filter((childNode) => childNode.owned.x)
+        .filter((childNode) => childNode.owned.left)
         .map((childNode) => childNode.bbox.left);
 
       const x = lefts.length === 0 ? 0 : maybeMin(lefts) ?? 0;
@@ -48,10 +48,10 @@ export const Background = withBluefish((props: BackgroundProps) => {
     } else {
       throw new Error("Background x must be inferred from children");
     }
-    if (!backgroundChild.owned.y) {
+    if (!backgroundChild.owned.top) {
       // infer y from rest
       const tops = rest
-        .filter((childNode) => childNode.owned.y)
+        .filter((childNode) => childNode.owned.top)
         .map((childNode) => childNode.bbox.top);
 
       const y = tops.length === 0 ? 0 : maybeMin(tops) ?? 0;
@@ -64,7 +64,7 @@ export const Background = withBluefish((props: BackgroundProps) => {
     if (!backgroundChild.owned.width) {
       // infer width from rest
       const rights = rest
-        .filter((childNode) => childNode.owned.x && childNode.owned.width)
+        .filter((childNode) => childNode.owned.left && childNode.owned.width)
         .map((childNode) =>
           maybeAdd(childNode.bbox.left, childNode.bbox.width)
         );
@@ -82,7 +82,7 @@ export const Background = withBluefish((props: BackgroundProps) => {
 
     // center all children horizontally in the background
     for (const childId of rest) {
-      if (childId.owned.x) continue;
+      if (childId.owned.left) continue;
       childId.bbox.left =
         left + (backgroundChild.bbox.width! - childId.bbox.width!) / 2;
     }
@@ -90,7 +90,7 @@ export const Background = withBluefish((props: BackgroundProps) => {
     if (!backgroundChild.owned.height) {
       // infer height from rest
       const bottoms = rest
-        .filter((childNode) => childNode.owned.y && childNode.owned.height)
+        .filter((childNode) => childNode.owned.top && childNode.owned.height)
         .map((childNode) =>
           maybeAdd(childNode.bbox.top, childNode.bbox.height)
         );
@@ -108,7 +108,7 @@ export const Background = withBluefish((props: BackgroundProps) => {
 
     // center all children vertically in the background
     for (const childId of rest) {
-      if (childId.owned.y) continue;
+      if (childId.owned.top) continue;
       childId.bbox.top =
         top + (backgroundChild.bbox.height! - childId.bbox.height!) / 2;
     }

--- a/src/bluefish.tsx
+++ b/src/bluefish.tsx
@@ -164,6 +164,7 @@ export function Bluefish(props: BluefishProps) {
         </ScopeContext.Provider>
       </ScenegraphContext.Provider>
       <Show when={props.debug === true}>
+        <br />
         <div style={{ float: "left", "margin-right": "40px" }}>
           <h1>Scenegraph</h1>
           <pre>{JSON.stringify(scenegraph, null, 2)}</pre>

--- a/src/bluefish.tsx
+++ b/src/bluefish.tsx
@@ -77,11 +77,11 @@ export function Bluefish(props: BluefishProps) {
   }
   const layout = (childNodes: ChildNode[]) => {
     for (const childNode of childNodes) {
-      if (!childNode.owned.x) {
+      if (!childNode.owned.left) {
         childNode.bbox.left = 0;
       }
 
-      if (!childNode.owned.y) {
+      if (!childNode.owned.top) {
         childNode.bbox.top = 0;
       }
     }

--- a/src/bluefish.tsx
+++ b/src/bluefish.tsx
@@ -111,11 +111,11 @@ export function Bluefish(props: BluefishProps) {
     return {
       transform: {
         translate: {
-          x: left,
-          y: top,
+          x: 0,
+          y: 0,
         },
       },
-      bbox: { left, top, right, bottom, width, height },
+      bbox: { left, top, width, height },
     };
   };
 
@@ -135,14 +135,10 @@ export function Bluefish(props: BluefishProps) {
         height={height()}
         viewBox={`${
           -props.padding! +
-          (props.positioning === "absolute"
-            ? 0
-            : paintProps.transform.translate.x ?? 0)
+          (props.positioning === "absolute" ? 0 : paintProps.bbox.left ?? 0)
         } ${
           -props.padding! +
-          (props.positioning === "absolute"
-            ? 0
-            : paintProps.transform.translate.y ?? 0)
+          (props.positioning === "absolute" ? 0 : paintProps.bbox.top ?? 0)
         } ${width()} ${height()}`}
       >
         {props.children}

--- a/src/bluefish.tsx
+++ b/src/bluefish.tsx
@@ -164,7 +164,14 @@ export function Bluefish(props: BluefishProps) {
         </ScopeContext.Provider>
       </ScenegraphContext.Provider>
       <Show when={props.debug === true}>
-        <pre>{JSON.stringify(scenegraph, null, 2)}</pre>
+        <div style={{ float: "left", "margin-right": "40px" }}>
+          <h1>Scenegraph</h1>
+          <pre>{JSON.stringify(scenegraph, null, 2)}</pre>
+        </div>
+        <div style={{ float: "left" }}>
+          <h1>Scope</h1>
+          <pre>{JSON.stringify(scope, null, 2)}</pre>
+        </div>
       </Show>
     </>
   );

--- a/src/chemistry/atom.tsx
+++ b/src/chemistry/atom.tsx
@@ -52,10 +52,10 @@ export type AtomProps = JSX.CircleSVGAttributes<SVGCircleElement> & {
 };
 
 export const Atom = withBluefish((props: AtomProps) => {
-  const numHydrogens = maxBonds[props.content] - props.bondCount;
-  const hydrogenString = "H".repeat(numHydrogens);
-  const atomContent =
-    props.content === "C" ? "" : props.content + hydrogenString;
+  const numHydrogens = () => maxBonds[props.content] - props.bondCount;
+  const hydrogenString = () => "H".repeat(numHydrogens());
+  const atomContent = () =>
+    props.content === "C" ? "" : props.content + hydrogenString();
   const layout = () => {
     return {
       bbox: {
@@ -81,7 +81,7 @@ export const Atom = withBluefish((props: AtomProps) => {
     return (
       <>
         {/* if atom content length is greater than 1, then render a rectangle instead */}
-        {atomContent.length > 1 ? (
+        {atomContent().length > 1 ? (
           <rect
             x={
               (paintProps.bbox.left ?? 0) -
@@ -92,7 +92,7 @@ export const Atom = withBluefish((props: AtomProps) => {
               (paintProps.bbox.top ?? 0) +
               (paintProps.transform.translate.y ?? 0)
             }
-            width={(paintProps.bbox.width ?? 0) * atomContent.length}
+            width={(paintProps.bbox.width ?? 0) * atomContent().length}
             height={paintProps.bbox.height ?? 0}
             fill={"white"}
             rx={r() / 2}
@@ -111,7 +111,7 @@ export const Atom = withBluefish((props: AtomProps) => {
               (paintProps.transform.translate.y ?? 0)
             }
             r={r()}
-            fill={atomContent.length === 0 ? "none" : "white"}
+            fill={atomContent().length === 0 ? "none" : "white"}
           />
         )}
         <text
@@ -129,7 +129,7 @@ export const Atom = withBluefish((props: AtomProps) => {
           text-anchor={"middle"}
           dominant-baseline="central"
         >
-          {atomContent}
+          {atomContent()}
         </text>
       </>
     );

--- a/src/chemistry/molecule.tsx
+++ b/src/chemistry/molecule.tsx
@@ -7,6 +7,7 @@ import SmilesDrawer from "smiles-drawer/app.js";
 import SvgDrawer from "smiles-drawer/src/SvgDrawer";
 import ThemeManager from "smiles-drawer/src/ThemeManager";
 import { For } from "solid-js";
+import Circle from "../circle";
 
 // Code for chemical molecule; integrates with Smiles Drawer
 export type MoleculeProps = { chemicalFormula: string; ariaLabel: string };
@@ -138,12 +139,12 @@ export const Molecule = withBluefish((props: MoleculeProps) => {
    * @param {Vertex[]} vertices An array of vertices containing the vertices associated with the current molecule.
    */
   function determineDimensions(svgWrapper: any, vertices: any) {
-    for (const i = 0; i < vertices.length; i++) {
-      if (!vertices[i].value.isDrawn) {
+    for (const vertex of vertices) {
+      if (!vertex.value.isDrawn) {
         continue;
       }
 
-      let p = vertices[i].position;
+      let p = vertex.position;
 
       if (svgWrapper.maxX < p.x) svgWrapper.maxX = p.x;
       if (svgWrapper.maxY < p.y) svgWrapper.maxY = p.y;

--- a/src/createName.tsx
+++ b/src/createName.tsx
@@ -43,3 +43,19 @@ export const createName = (name: string) => {
 
   return genId;
 };
+
+export const resolveName = (
+  layoutNode: Id,
+  options?: { default?: boolean }
+): Name | undefined => {
+  options = {
+    default: true,
+    ...options,
+  };
+  const [scope] = useContext(ScopeContext);
+  const name = Object.keys(scope).find(
+    (name) => scope[name].layoutNode === layoutNode
+  );
+
+  return name ?? (options?.default ? layoutNode : undefined);
+};

--- a/src/distribute.tsx
+++ b/src/distribute.tsx
@@ -16,7 +16,6 @@ export type DistributeProps = ParentProps<{
 
 export const Distribute = withBluefish((props: DistributeProps) => {
   const layout = (childNodes: ChildNode[]) => {
-    // debugger;
     childNodes = Array.from(childNodes);
 
     if (props.name.endsWith("DEBUG")) {
@@ -113,11 +112,9 @@ export const Distribute = withBluefish((props: DistributeProps) => {
         y += childId.bbox.height! + spacing;
       }
 
-      // TODO: is the width computation correct? should it take position into account?
       return {
         bbox: {
           top: startingY,
-          width: maybeMax(childNodes.map((childId) => childId.bbox.width)),
           height,
         },
         transform: {
@@ -211,11 +208,9 @@ export const Distribute = withBluefish((props: DistributeProps) => {
         x += childId.bbox.width! + spacing;
       }
 
-      // TODO: is the height computation correct? should it take position into account?
       return {
         bbox: {
           left: startingX,
-          height: maybeMax(childNodes.map((childId) => childId.bbox.height)),
           width,
         },
         transform: {

--- a/src/distribute.tsx
+++ b/src/distribute.tsx
@@ -90,7 +90,7 @@ export const Distribute = withBluefish((props: DistributeProps) => {
         throw new Error("invalid options");
       }
 
-      const fixedElement = childNodes.findIndex((childId) => childId.owned.y);
+      const fixedElement = childNodes.findIndex((childId) => childId.owned.top);
 
       // use spacing and height to evenly distribute elements while ensuring that the fixed element
       // is fixed
@@ -107,7 +107,7 @@ export const Distribute = withBluefish((props: DistributeProps) => {
       // subtract off spacing and the sizes of the first fixedElement elements
       let y = startingY;
       for (const childId of childNodes) {
-        if (!childId.owned.y) {
+        if (!childId.owned.top) {
           childId.bbox.top = y;
         }
         y += childId.bbox.height! + spacing;
@@ -186,7 +186,9 @@ export const Distribute = withBluefish((props: DistributeProps) => {
         throw new Error("Invalid options for space");
       }
 
-      const fixedElement = childNodes.findIndex((childId) => childId.owned.x);
+      const fixedElement = childNodes.findIndex(
+        (childId) => childId.owned.left
+      );
 
       // use spacing and width to evenly distribute elements while ensuring that the fixed element
       // is fixed
@@ -203,7 +205,7 @@ export const Distribute = withBluefish((props: DistributeProps) => {
       // subtract off spacing and the sizes of the first fixedElement elements
       let x = startingX;
       for (const childId of childNodes) {
-        if (!childId.owned.x) {
+        if (!childId.owned.left) {
           childId.bbox.left = x;
         }
         x += childId.bbox.width! + spacing;

--- a/src/group.tsx
+++ b/src/group.tsx
@@ -30,11 +30,11 @@ export const Group = withBluefish((props: GroupProps) => {
     }
 
     for (const childNode of childNodes) {
-      if (!childNode.owned.x) {
+      if (!childNode.owned.left) {
         childNode.bbox.left = 0;
       }
 
-      if (!childNode.owned.y) {
+      if (!childNode.owned.top) {
         childNode.bbox.top = 0;
       }
     }

--- a/src/layout.tsx
+++ b/src/layout.tsx
@@ -26,7 +26,7 @@ import { IdContext } from "./withBluefish";
 
 export type LayoutProps = ParentProps<{
   name: Id;
-  bbox?: Partial<BBox>;
+  bbox?: BBox;
   layout: LayoutFn;
   paint: (props: {
     bbox: BBox;

--- a/src/scenegraph.ts
+++ b/src/scenegraph.ts
@@ -357,7 +357,9 @@ the align node.
     for (const key of Object.keys(bbox) as Array<Dim>) {
       if (bbox[key] !== undefined && isNaN(bbox[key]!)) {
         console.error(
-          `setBBox: ${owner} tried to update ${id}'s bbox with ${JSON.stringify(
+          `setBBox: ${resolveName(owner)} tried to update ${resolveName(
+            id
+          )}'s bbox with ${JSON.stringify(
             bbox
           )}, but the bbox contains NaN values. Skipping...`
         );
@@ -464,7 +466,7 @@ the align node.
           node.transformOwners.translate.y = newTransformOwners.translate.y;
         }
 
-        propagateBBoxValues(bbox, node.bboxOwners);
+        propagateBBoxValues(node.bbox, node.bboxOwners);
       })
     );
   };

--- a/src/scenegraph.ts
+++ b/src/scenegraph.ts
@@ -543,8 +543,10 @@ the align node.
           // NOTE: this case doesn't always happen. e.g. `right` could be set before `left` in which
           // case `right` has already set the translate.x
           proposedTransform.translate[axis] = 0;
+          proposedBBox[dim] = bbox[dim]!;
+        } else {
+          proposedBBox[dim] = bbox[dim]! - node.transform.translate[axis]!;
         }
-        proposedBBox[dim] = bbox[dim]! - node.transform.translate[axis]!;
       } else if (
         node.transformOwners.translate[axis] === owner ||
         node.transformOwners.translate[axis] === undefined

--- a/src/scenegraph.ts
+++ b/src/scenegraph.ts
@@ -574,21 +574,21 @@ the align node.
 
     if (dim === "left" || dim === "centerX" || dim === "right") {
       return !(
-        node.bboxOwners[dim] === undefined &&
-        node.bboxOwners[dim] === id &&
-        node.transformOwners.translate.x === undefined &&
+        node.bboxOwners[dim] === undefined ||
+        node.bboxOwners[dim] === id ||
+        node.transformOwners.translate.x === undefined ||
         node.transformOwners.translate.x === id
       );
     } else if (dim === "top" || dim === "centerY" || dim === "bottom") {
       return !(
-        node.bboxOwners[dim] === undefined &&
-        node.bboxOwners[dim] === id &&
-        node.transformOwners.translate.y === undefined &&
+        node.bboxOwners[dim] === undefined ||
+        node.bboxOwners[dim] === id ||
+        node.transformOwners.translate.y === undefined ||
         node.transformOwners.translate.y === id
       );
     } else if (dim === "width" || dim === "height") {
       return !(
-        node.bboxOwners[dim] === undefined && node.bboxOwners[dim] === id
+        node.bboxOwners[dim] === undefined || node.bboxOwners[dim] === id
       );
     } else {
       throw new Error(`Invalid dim: ${dim}`);

--- a/src/scenegraph.ts
+++ b/src/scenegraph.ts
@@ -4,6 +4,7 @@ import _ from "lodash";
 import { maybeAdd, maybeAddAll, maybeDiv, maybeSub } from "./util/maybe";
 import { createContext, useContext } from "solid-js";
 import { BBox, Dim, Axis, axisMap, inferenceRules } from "./util/bbox";
+import { resolveName } from "./createName";
 
 export type Id = string;
 export type Inferred = { inferred: true };
@@ -377,7 +378,13 @@ the align node.
             node.bboxOwners[key] !== owner
           ) {
             console.error(
-              `${owner} tried to set ${id}'s ${key} to ${bbox[key]} but it was already set by ${node.bboxOwners[key]}. Only one component can set a bbox property. We skipped this update.`
+              `${resolveName(owner)} tried to set ${resolveName(
+                id
+              )}'s ${key} to ${
+                bbox[key]
+              } but it was already set by ${resolveName(
+                node.bboxOwners[key]! as any /* TODO: handle inferred case */
+              )}. Only one component can set a bbox property. We skipped this update.`
             );
             return node;
           }
@@ -393,7 +400,15 @@ the align node.
             node.transformOwners.translate[key] !== owner
           ) {
             console.error(
-              `${owner} tried to set ${id}'s translate.${key} to ${transform?.translate[key]} but it was already set by ${node.transformOwners.translate[key]}. Only one component can set a transform property. We skipped this update.`
+              `${resolveName(owner)} tried to set ${resolveName(
+                id
+              )}'s translate.${key} to ${
+                transform?.translate[key]
+              } but it was already set by ${resolveName(
+                node.transformOwners.translate[
+                  key
+                ]! as any /* TODO: handle inferred case */
+              )}. Only one component can set a transform property. We skipped this update.`
             );
             return node;
           }
@@ -478,7 +493,9 @@ the align node.
       if (bbox[key] !== undefined && isNaN(bbox[key]!)) {
         // error message should include id, bbox, owner
         console.error(
-          `setBBox: ${owner} tried to update ${resolvedId}'s bbox with ${JSON.stringify(
+          `setBBox: ${resolveName(owner)} tried to update ${resolveName(
+            resolvedId
+          )}'s bbox with ${JSON.stringify(
             bbox
           )}, but the bbox contains NaN values. Skipping...`
         );
@@ -506,7 +523,11 @@ the align node.
       const axis = axisMap[dim];
       if (accumulatedTransform.translate[axis] === undefined) {
         console.error(
-          `setBBox: ${owner} tried to update ${resolvedId}'s bbox.${dim} with ${bbox[dim]}, but the accumulated transform.translate.${axis} is undefined. Skipping...`
+          `setBBox: ${resolveName(owner)} tried to update ${resolveName(
+            resolvedId
+          )}'s bbox.${dim} with ${
+            bbox[dim]
+          }, but the accumulated transform.translate.${axis} is undefined. Skipping...`
         );
         continue;
       }
@@ -529,7 +550,13 @@ the align node.
         proposedTransform.translate[axis] = bbox[dim]! - node.bbox[dim]!;
       } else {
         console.error(
-          `setBBox: ${owner} tried to update ${resolvedId}'s bbox.${dim} with ${bbox[dim]}, but it was already set by ${node.bboxOwners[dim]}. Only one component can set a bbox property. We skipped this update.`
+          `setBBox: ${resolveName(owner)} tried to update ${resolveName(
+            resolvedId
+          )}'s bbox.${dim} with ${
+            bbox[dim]
+          }, but it was already set by ${resolveName(
+            node.bboxOwners[dim]! as any /* TODO: handle inferred case */
+          )}. Only one component can set a bbox property. We skipped this update.`
         );
         return;
       }
@@ -545,7 +572,13 @@ the align node.
         proposedBBox[dim] = bbox[dim]!;
       } else {
         console.error(
-          `setBBox: ${owner} tried to update ${resolvedId}'s bbox.${dim} with ${bbox[dim]}, but it was already set by ${node.bboxOwners[dim]}. Only one component can set a bbox property. We skipped this update.`
+          `setBBox: ${resolveName(owner)} tried to update ${resolveName(
+            resolvedId
+          )}'s bbox.${dim} with ${
+            bbox[dim]
+          }, but it was already set by ${resolveName(
+            node.bboxOwners[dim]! as any /* TODO: handle inferred case */
+          )}. Only one component can set a bbox property. We skipped this update.`
         );
         return;
       }
@@ -605,7 +638,9 @@ the align node.
         set left(left: number | undefined) {
           if (left === undefined) {
             console.error(
-              `${owner} tried to set ${childId}'s left to undefined. Skipping...`
+              `${resolveName(owner)} tried to set ${resolveName(
+                childId
+              )}'s left to undefined. Skipping...`
             );
             return;
           }
@@ -618,7 +653,9 @@ the align node.
         set centerX(centerX: number | undefined) {
           if (centerX === undefined) {
             console.error(
-              `${owner} tried to set ${childId}'s centerX to undefined. Skipping...`
+              `${resolveName(owner)} tried to set ${resolveName(
+                childId
+              )}'s centerX to undefined. Skipping...`
             );
             return;
           }
@@ -631,7 +668,9 @@ the align node.
         set right(right: number | undefined) {
           if (right === undefined) {
             console.error(
-              `${owner} tried to set ${childId}'s right to undefined. Skipping...`
+              `${resolveName(owner)} tried to set ${resolveName(
+                childId
+              )}'s right to undefined. Skipping...`
             );
             return;
           }
@@ -644,7 +683,9 @@ the align node.
         set top(top: number | undefined) {
           if (top === undefined) {
             console.error(
-              `${owner} tried to set ${childId}'s top to undefined. Skipping...`
+              `${resolveName(owner)} tried to set ${resolveName(
+                childId
+              )}'s top to undefined. Skipping...`
             );
             return;
           }
@@ -657,7 +698,9 @@ the align node.
         set centerY(centerY: number | undefined) {
           if (centerY === undefined) {
             console.error(
-              `${owner} tried to set ${childId}'s centerY to undefined. Skipping...`
+              `${resolveName(owner)} tried to set ${resolveName(
+                childId
+              )}'s centerY to undefined. Skipping...`
             );
             return;
           }
@@ -670,7 +713,9 @@ the align node.
         set bottom(bottom: number | undefined) {
           if (bottom === undefined) {
             console.error(
-              `${owner} tried to set ${childId}'s bottom to undefined. Skipping...`
+              `${resolveName(owner)} tried to set ${resolveName(
+                childId
+              )}'s bottom to undefined. Skipping...`
             );
             return;
           }
@@ -683,7 +728,9 @@ the align node.
         set width(width: number | undefined) {
           if (width === undefined) {
             console.error(
-              `${owner} tried to set ${childId}'s width to undefined. Skipping...`
+              `${resolveName(owner)} tried to set ${resolveName(
+                childId
+              )}'s width to undefined. Skipping...`
             );
             return;
           }
@@ -696,7 +743,9 @@ the align node.
         set height(height: number | undefined) {
           if (height === undefined) {
             console.error(
-              `${owner} tried to set ${childId}'s height to undefined. Skipping...`
+              `${resolveName(owner)} tried to set ${resolveName(
+                childId
+              )}'s height to undefined. Skipping...`
             );
             return;
           }

--- a/src/stackLayout.ts
+++ b/src/stackLayout.ts
@@ -22,99 +22,123 @@ export type StackArgs = {
 export const stackLayout =
   (args: StackArgs): LayoutFn =>
   (childNodes: ChildNode[]) => {
+    debugger;
     if (args.name.endsWith("DEBUG")) {
       debugger;
     }
 
     /* ALIGNMENT */
-    const verticalAlignments = childNodes
-      .map((m) => /* m.guidePrimary ?? */ args.alignment)
-      .map((alignment) => maybe(alignment, verticalAlignment));
-
-    const horizontalAlignments = childNodes
-      .map((m) => /* m.guidePrimary ?? */ args.alignment)
-      .map((alignment) => maybe(alignment, horizontalAlignment));
-
-    const verticalPlaceables = _.zip(childNodes, verticalAlignments).filter(
-      ([placeable, alignment]) => alignment !== undefined
+    const alignments = childNodes.map(
+      (m) => /* m.guidePrimary ?? */ args.alignment
     );
 
-    const horizontalPlaceables = _.zip(childNodes, horizontalAlignments).filter(
+    const placeables = _.zip(childNodes, alignments).filter(
       ([placeable, alignment]) => alignment !== undefined
-    );
+    ) as [ChildNode, Alignment1D][];
 
-    // TODO: should be able to filter by ownership instead
-    const verticalValueArr = verticalPlaceables
-      .filter(([placeable, _]) => placeable!.owned.top)
-      .map(([placeable, alignment]) => {
-        return [
-          placeable,
-          alignment !== undefined ? placeable!.bbox[alignment] : undefined,
-        ];
-      })
+    const existingPositions = placeables
       .filter(
-        ([placeable, value]) =>
-          // scenegraph[placeable!].transformOwners.translate.y !== id &&
-          value !== undefined
-      );
-
-    // TODO: we should probably make it so that the default value depends on the x & y args
-    const verticalValue =
-      verticalValueArr.length === 0 ? 0 : (verticalValueArr[0][1] as number);
-
-    const horizontalValueArr = horizontalPlaceables
-      .filter(([placeable, _]) => placeable!.owned.left)
+        ([placeable, alignment]) => placeable!.owned[alignment as BBox.Dim]
+      )
       .map(([placeable, alignment]) => {
-        return [
-          placeable,
-          alignment !== undefined ? placeable!.bbox[alignment] : undefined,
-        ];
-      })
-      .filter(
-        ([placeable, value]) =>
-          // scenegraph[placeable!].transformOwners.translate.x !== id &&
-          value !== undefined
-      );
+        return [placeable!, placeable!.bbox[alignment as BBox.Dim]!];
+      }) satisfies [ChildNode, number][];
 
-    const horizontalValue =
-      horizontalValueArr.length === 0
-        ? 0
-        : (horizontalValueArr[0][1] as number);
+    const defaultValue = existingPositions[0]?.[1] ?? 0;
 
-    for (const [placeable, alignment] of verticalPlaceables) {
-      if (placeable!.owned.top) continue;
-      if (alignment === "top") {
-        placeable!.bbox.top = verticalValue;
-      } else if (alignment === "centerY") {
-        const height = placeable!.bbox.height;
-        if (height === undefined) {
-          continue;
-        }
-        placeable!.bbox.top = verticalValue - height / 2;
-      } else if (alignment === "bottom") {
-        placeable!.bbox.top = verticalValue - placeable!.bbox.height!;
-      }
+    // const verticalAlignments = childNodes
+    //   .map((m) => /* m.guidePrimary ?? */ args.alignment)
+    //   .map((alignment) => maybe(alignment, verticalAlignment));
+
+    // const horizontalAlignments = childNodes
+    //   .map((m) => /* m.guidePrimary ?? */ args.alignment)
+    //   .map((alignment) => maybe(alignment, horizontalAlignment));
+
+    // const verticalPlaceables = _.zip(childNodes, verticalAlignments).filter(
+    //   ([placeable, alignment]) => alignment !== undefined
+    // );
+
+    // const horizontalPlaceables = _.zip(childNodes, horizontalAlignments).filter(
+    //   ([placeable, alignment]) => alignment !== undefined
+    // );
+
+    // // TODO: should be able to filter by ownership instead
+    // const verticalValueArr = verticalPlaceables
+    //   .filter(([placeable, _]) => placeable!.owned.top)
+    //   .map(([placeable, alignment]) => {
+    //     return [
+    //       placeable,
+    //       alignment !== undefined ? placeable!.bbox[alignment] : undefined,
+    //     ];
+    //   })
+    //   .filter(
+    //     ([placeable, value]) =>
+    //       // scenegraph[placeable!].transformOwners.translate.y !== id &&
+    //       value !== undefined
+    //   );
+
+    // // TODO: we should probably make it so that the default value depends on the x & y args
+    // const verticalValue =
+    //   verticalValueArr.length === 0 ? 0 : (verticalValueArr[0][1] as number);
+
+    // const horizontalValueArr = horizontalPlaceables
+    //   .filter(([placeable, _]) => placeable!.owned.left)
+    //   .map(([placeable, alignment]) => {
+    //     return [
+    //       placeable,
+    //       alignment !== undefined ? placeable!.bbox[alignment] : undefined,
+    //     ];
+    //   })
+    //   .filter(
+    //     ([placeable, value]) =>
+    //       // scenegraph[placeable!].transformOwners.translate.x !== id &&
+    //       value !== undefined
+    //   );
+
+    // const horizontalValue =
+    //   horizontalValueArr.length === 0
+    //     ? 0
+    //     : (horizontalValueArr[0][1] as number);
+
+    for (const [placeable, alignment] of placeables) {
+      if (placeable!.owned[alignment as BBox.Dim]) continue;
+      placeable!.bbox[alignment as BBox.Dim] = defaultValue;
     }
 
-    for (const [placeable, alignment] of horizontalPlaceables) {
-      if (placeable!.owned.left) continue;
-      if (alignment === "left") {
-        placeable!.bbox.left = horizontalValue;
-      } else if (alignment === "centerX") {
-        const width = placeable!.bbox.width;
-        if (width === undefined) {
-          continue;
-        }
-        placeable!.bbox.left = horizontalValue - width / 2;
-      } else if (alignment === "right") {
-        // placeable!.right = horizontalValue;
-        const width = placeable!.bbox.width;
-        if (width === undefined) {
-          continue;
-        }
-        placeable!.bbox.left = horizontalValue - width;
-      }
-    }
+    // for (const [placeable, alignment] of verticalPlaceables) {
+    //   if (placeable!.owned.top) continue;
+    //   if (alignment === "top") {
+    //     placeable!.bbox.top = verticalValue;
+    //   } else if (alignment === "centerY") {
+    //     const height = placeable!.bbox.height;
+    //     if (height === undefined) {
+    //       continue;
+    //     }
+    //     placeable!.bbox.top = verticalValue - height / 2;
+    //   } else if (alignment === "bottom") {
+    //     placeable!.bbox.top = verticalValue - placeable!.bbox.height!;
+    //   }
+    // }
+
+    // for (const [placeable, alignment] of horizontalPlaceables) {
+    //   if (placeable!.owned.left) continue;
+    //   if (alignment === "left") {
+    //     placeable!.bbox.left = horizontalValue;
+    //   } else if (alignment === "centerX") {
+    //     const width = placeable!.bbox.width;
+    //     if (width === undefined) {
+    //       continue;
+    //     }
+    //     placeable!.bbox.left = horizontalValue - width / 2;
+    //   } else if (alignment === "right") {
+    //     // placeable!.right = horizontalValue;
+    //     const width = placeable!.bbox.width;
+    //     if (width === undefined) {
+    //       continue;
+    //     }
+    //     placeable!.bbox.left = horizontalValue - width;
+    //   }
+    // }
 
     /* DISTRIBUTE */
     if (args.direction === "vertical") {

--- a/src/stackLayout.ts
+++ b/src/stackLayout.ts
@@ -22,7 +22,6 @@ export type StackArgs = {
 export const stackLayout =
   (args: StackArgs): LayoutFn =>
   (childNodes: ChildNode[]) => {
-    debugger;
     if (args.name.endsWith("DEBUG")) {
       debugger;
     }
@@ -46,99 +45,10 @@ export const stackLayout =
 
     const defaultValue = existingPositions[0]?.[1] ?? 0;
 
-    // const verticalAlignments = childNodes
-    //   .map((m) => /* m.guidePrimary ?? */ args.alignment)
-    //   .map((alignment) => maybe(alignment, verticalAlignment));
-
-    // const horizontalAlignments = childNodes
-    //   .map((m) => /* m.guidePrimary ?? */ args.alignment)
-    //   .map((alignment) => maybe(alignment, horizontalAlignment));
-
-    // const verticalPlaceables = _.zip(childNodes, verticalAlignments).filter(
-    //   ([placeable, alignment]) => alignment !== undefined
-    // );
-
-    // const horizontalPlaceables = _.zip(childNodes, horizontalAlignments).filter(
-    //   ([placeable, alignment]) => alignment !== undefined
-    // );
-
-    // // TODO: should be able to filter by ownership instead
-    // const verticalValueArr = verticalPlaceables
-    //   .filter(([placeable, _]) => placeable!.owned.top)
-    //   .map(([placeable, alignment]) => {
-    //     return [
-    //       placeable,
-    //       alignment !== undefined ? placeable!.bbox[alignment] : undefined,
-    //     ];
-    //   })
-    //   .filter(
-    //     ([placeable, value]) =>
-    //       // scenegraph[placeable!].transformOwners.translate.y !== id &&
-    //       value !== undefined
-    //   );
-
-    // // TODO: we should probably make it so that the default value depends on the x & y args
-    // const verticalValue =
-    //   verticalValueArr.length === 0 ? 0 : (verticalValueArr[0][1] as number);
-
-    // const horizontalValueArr = horizontalPlaceables
-    //   .filter(([placeable, _]) => placeable!.owned.left)
-    //   .map(([placeable, alignment]) => {
-    //     return [
-    //       placeable,
-    //       alignment !== undefined ? placeable!.bbox[alignment] : undefined,
-    //     ];
-    //   })
-    //   .filter(
-    //     ([placeable, value]) =>
-    //       // scenegraph[placeable!].transformOwners.translate.x !== id &&
-    //       value !== undefined
-    //   );
-
-    // const horizontalValue =
-    //   horizontalValueArr.length === 0
-    //     ? 0
-    //     : (horizontalValueArr[0][1] as number);
-
     for (const [placeable, alignment] of placeables) {
       if (placeable!.owned[alignment as BBox.Dim]) continue;
       placeable!.bbox[alignment as BBox.Dim] = defaultValue;
     }
-
-    // for (const [placeable, alignment] of verticalPlaceables) {
-    //   if (placeable!.owned.top) continue;
-    //   if (alignment === "top") {
-    //     placeable!.bbox.top = verticalValue;
-    //   } else if (alignment === "centerY") {
-    //     const height = placeable!.bbox.height;
-    //     if (height === undefined) {
-    //       continue;
-    //     }
-    //     placeable!.bbox.top = verticalValue - height / 2;
-    //   } else if (alignment === "bottom") {
-    //     placeable!.bbox.top = verticalValue - placeable!.bbox.height!;
-    //   }
-    // }
-
-    // for (const [placeable, alignment] of horizontalPlaceables) {
-    //   if (placeable!.owned.left) continue;
-    //   if (alignment === "left") {
-    //     placeable!.bbox.left = horizontalValue;
-    //   } else if (alignment === "centerX") {
-    //     const width = placeable!.bbox.width;
-    //     if (width === undefined) {
-    //       continue;
-    //     }
-    //     placeable!.bbox.left = horizontalValue - width / 2;
-    //   } else if (alignment === "right") {
-    //     // placeable!.right = horizontalValue;
-    //     const width = placeable!.bbox.width;
-    //     if (width === undefined) {
-    //       continue;
-    //     }
-    //     placeable!.bbox.left = horizontalValue - width;
-    //   }
-    // }
 
     /* DISTRIBUTE */
     if (args.direction === "vertical") {

--- a/src/stackLayout.ts
+++ b/src/stackLayout.ts
@@ -45,7 +45,7 @@ export const stackLayout =
 
     // TODO: should be able to filter by ownership instead
     const verticalValueArr = verticalPlaceables
-      .filter(([placeable, _]) => placeable!.owned.y)
+      .filter(([placeable, _]) => placeable!.owned.top)
       .map(([placeable, alignment]) => {
         return [
           placeable,
@@ -63,7 +63,7 @@ export const stackLayout =
       verticalValueArr.length === 0 ? 0 : (verticalValueArr[0][1] as number);
 
     const horizontalValueArr = horizontalPlaceables
-      .filter(([placeable, _]) => placeable!.owned.x)
+      .filter(([placeable, _]) => placeable!.owned.left)
       .map(([placeable, alignment]) => {
         return [
           placeable,
@@ -82,7 +82,7 @@ export const stackLayout =
         : (horizontalValueArr[0][1] as number);
 
     for (const [placeable, alignment] of verticalPlaceables) {
-      if (placeable!.owned.y) continue;
+      if (placeable!.owned.top) continue;
       if (alignment === "top") {
         placeable!.bbox.top = verticalValue;
       } else if (alignment === "centerY") {
@@ -97,7 +97,7 @@ export const stackLayout =
     }
 
     for (const [placeable, alignment] of horizontalPlaceables) {
-      if (placeable!.owned.x) continue;
+      if (placeable!.owned.left) continue;
       if (alignment === "left") {
         placeable!.bbox.left = horizontalValue;
       } else if (alignment === "centerX") {
@@ -180,7 +180,7 @@ export const stackLayout =
         throw new Error("invalid options");
       }
 
-      const fixedElement = childNodes.findIndex((childId) => childId.owned.y);
+      const fixedElement = childNodes.findIndex((childId) => childId.owned.top);
 
       // use spacing and height to evenly distribute elements while ensuring that the fixed element
       // is fixed
@@ -197,7 +197,7 @@ export const stackLayout =
       // subtract off spacing and the sizes of the first fixedElement elements
       let y = startingY;
       for (const childId of childNodes) {
-        if (!childId.owned.y) {
+        if (!childId.owned.top) {
           childId.bbox.top = y;
         }
         y += childId.bbox.height! + spacing;
@@ -282,7 +282,9 @@ export const stackLayout =
         throw new Error("Invalid options for space");
       }
 
-      const fixedElement = childNodes.findIndex((childId) => childId.owned.x);
+      const fixedElement = childNodes.findIndex(
+        (childId) => childId.owned.left
+      );
 
       // use spacing and width to evenly distribute elements while ensuring that the fixed element
       // is fixed
@@ -299,7 +301,7 @@ export const stackLayout =
       // subtract off spacing and the sizes of the first fixedElement elements
       let x = startingX;
       for (const childId of childNodes) {
-        if (!childId.owned.x) {
+        if (!childId.owned.left) {
           childId.bbox.left = x;
         }
         x += childId.bbox.width! + spacing;

--- a/src/stories/44.stories.tsx
+++ b/src/stories/44.stories.tsx
@@ -1,0 +1,45 @@
+import { Meta, StoryObj } from "storybook-solidjs";
+import Bluefish from "../bluefish";
+import Group from "../group";
+import Rect from "../rect";
+import Distribute from "../distribute";
+import Align from "../align";
+import Ref from "../ref";
+import { createSignal } from "solid-js";
+import Background from "../background";
+import { StackH } from "../stackh";
+import { Text } from "../text";
+import Circle from "../circle";
+import Arrow from "../arrow";
+
+const meta: Meta = {
+  title: "Regression/#44",
+};
+
+export default meta;
+type Story = StoryObj;
+
+export const App: Story = {
+  name: "#44",
+  render: () => {
+    return (
+      <Bluefish>
+        <Distribute direction="vertical" spacing={20}>
+          <StackH spacing={200}>
+            <Rect name="left" width={100} height={200} fill="magenta" />
+            <Rect name="right" width={100} height={100} fill="green" />
+          </StackH>
+          <Rect name="test" height={100} fill="black" />
+        </Distribute>
+        <Align alignment="left">
+          <Ref select="left" />
+          <Ref select="test" />
+        </Align>
+        <Align alignment="right">
+          <Ref select="right" />
+          <Ref select="test" />
+        </Align>
+      </Bluefish>
+    );
+  },
+};

--- a/src/stories/Molecule.stories.tsx
+++ b/src/stories/Molecule.stories.tsx
@@ -5,7 +5,6 @@
 import type { Meta, StoryObj } from "storybook-solidjs";
 import { Bluefish } from "../bluefish";
 import { Molecule } from "../chemistry/molecule";
-import Background from "../background";
 
 const meta: Meta = {
   title: "Example/Molecule",

--- a/src/stories/components/Align.stories.tsx
+++ b/src/stories/components/Align.stories.tsx
@@ -4,6 +4,9 @@ import { Bluefish } from "../../bluefish";
 import { Rect } from "../../rect";
 import Group from "../../group";
 import Distribute from "../../distribute";
+import Ref from "../../ref";
+import { StackH } from "../../stackh";
+import Background from "../../background";
 
 /**
  * Bluefish's `Align` component contains many different options for aligning its children components. Taking in any number of components as children,
@@ -54,27 +57,44 @@ export const AlignComponent: Story = {
   render: (props) => {
     return (
       <Bluefish>
-        <Distribute direction="horizontal" spacing={50}>
-          <Group>
-            <Align name="verticalAlign" alignment={props.alignment1}>
-              <Rect x={20} width={30} height={30} fill={"red"} />
-              <Rect x={70} width={50} height={50} fill={"blue"} />
-              <Rect x={160} width={80} height={80} fill={"green"} />
-            </Align>
-          </Group>
-          <Group>
-            <Align name="horizontalAlign" alignment={props.alignment2}>
-              <Rect y={20} width={30} height={30} fill={"red"} />
-              <Rect y={60} width={50} height={50} fill={"blue"} />
-            </Align>
-          </Group>
-          <Group>
-            <Align name="otherAlign" alignment={props.alignment3}>
-              <Rect width={50} height={50} fill={"blue"} />
-              <Rect width={30} height={30} fill={"red"} />
-            </Align>
-          </Group>
-        </Distribute>
+        <StackH spacing={100}>
+          <Background>
+            <Group>
+              <Rect name="rect1" x={20} width={30} height={30} fill={"red"} />
+              <Rect name="rect2" x={80} width={50} height={50} fill={"blue"} />
+              <Rect
+                name="rect3"
+                x={140}
+                width={80}
+                height={80}
+                fill={"green"}
+              />
+              <Align name="verticalAlign" alignment={props.alignment1}>
+                <Ref select="rect1" />
+                <Ref select="rect2" />
+                <Ref select="rect3" />
+              </Align>
+            </Group>
+          </Background>
+          <Background>
+            <Group>
+              <Rect name="rect4" y={20} width={30} height={30} fill={"red"} />
+              <Rect name="rect5" y={60} width={50} height={50} fill={"blue"} />
+              <Align name="horizontalAlign" alignment={props.alignment2}>
+                <Ref select="rect4" />
+                <Ref select="rect5" />
+              </Align>
+            </Group>
+          </Background>
+          <Background>
+            <Group>
+              <Align name="otherAlign" alignment={props.alignment3}>
+                <Rect width={50} height={50} fill={"blue"} />
+                <Rect width={30} height={30} fill={"red"} />
+              </Align>
+            </Group>
+          </Background>
+        </StackH>
       </Bluefish>
     );
   },

--- a/src/util/bbox.ts
+++ b/src/util/bbox.ts
@@ -1,15 +1,16 @@
 import { maybeAdd, maybeDiv, maybeMax, maybeMin, maybeSub } from "./maybe";
 
-export type BBox = {
-  left?: number;
-  top?: number;
-  right?: number;
-  bottom?: number;
-  centerX?: number;
-  centerY?: number;
-  width?: number;
-  height?: number;
-};
+export type Dim =
+  | "left"
+  | "top"
+  | "centerX"
+  | "centerY"
+  | "right"
+  | "bottom"
+  | "width"
+  | "height";
+
+export type BBox = { [key in Dim]?: number };
 
 export const from = (bboxes: BBox[]): BBox => {
   const bboxesStructOfArray = {

--- a/src/util/bbox.ts
+++ b/src/util/bbox.ts
@@ -10,6 +10,19 @@ export type Dim =
   | "width"
   | "height";
 
+export type Axis = "x" | "y";
+
+export const axisMap: { [key in Dim]: "x" | "y" } = {
+  left: "x",
+  centerX: "x",
+  right: "x",
+  top: "y",
+  centerY: "y",
+  bottom: "y",
+  width: "x",
+  height: "y",
+};
+
 export type BBox = { [key in Dim]?: number };
 
 export const from = (bboxes: BBox[]): BBox => {
@@ -53,3 +66,76 @@ export const from = (bboxes: BBox[]): BBox => {
     height,
   };
 };
+
+// This is basically a baked version of an LP solver for bbox constraints.
+// TODO: These rules are not complete. e.g. left = centerX - width / 2 is missing.
+export const inferenceRules: {
+  from: Dim[];
+  to: Dim;
+  calculate: (dims: number[]) => number;
+}[] = [
+  // width = right - left
+  {
+    from: ["right", "width"],
+    to: "left",
+    calculate: ([right, width]) => right - width,
+  },
+  {
+    from: ["left", "width"],
+    to: "right",
+    calculate: ([left, width]) => left + width,
+  },
+  {
+    from: ["left", "right"],
+    to: "width",
+    calculate: ([left, right]) => right - left,
+  },
+  // height = bottom - top
+  {
+    from: ["bottom", "height"],
+    to: "top",
+    calculate: ([bottom, height]) => bottom - height,
+  },
+  {
+    from: ["top", "height"],
+    to: "bottom",
+    calculate: ([top, height]) => top + height,
+  },
+  {
+    from: ["top", "bottom"],
+    to: "height",
+    calculate: ([top, bottom]) => bottom - top,
+  },
+  // centerX = (left + right) / 2
+  {
+    from: ["left", "right"],
+    to: "centerX",
+    calculate: ([left, right]) => (left + right) / 2,
+  },
+  {
+    from: ["left", "centerX"],
+    to: "right",
+    calculate: ([left, centerX]) => centerX * 2 - left,
+  },
+  {
+    from: ["right", "centerX"],
+    to: "left",
+    calculate: ([right, centerX]) => centerX * 2 - right,
+  },
+  // centerY = (top + bottom) / 2
+  {
+    from: ["top", "bottom"],
+    to: "centerY",
+    calculate: ([top, bottom]) => (top + bottom) / 2,
+  },
+  {
+    from: ["top", "centerY"],
+    to: "bottom",
+    calculate: ([top, centerY]) => centerY * 2 - top,
+  },
+  {
+    from: ["bottom", "centerY"],
+    to: "top",
+    calculate: ([bottom, centerY]) => centerY * 2 - bottom,
+  },
+];


### PR DESCRIPTION
This PR adds the ability to e.g. set `left` and `right` and infer `width`. Previously, `right` was _always_ inferred, but now it can be set directly and its result will be propagated to the other dimensions.

The approach is roughly to bake in a linear programming solver for this special case of bbox equations. The current approach is not optimized and the set of inference rules that implement the bbox equations is not complete. But I think we should ship it in its current state and fix later as bugs arise in real examples.

This PR enables the Peritext example, where spans are driven by their `left` and `right` extents.